### PR TITLE
Column sorting in SparseMatrixBuilder

### DIFF
--- a/src/iterators.jl
+++ b/src/iterators.jl
@@ -250,7 +250,10 @@ end
 
 function finalisecolumn!(s::SparseMatrixBuilder, sortcol::Bool = false)
     s.colcounter > s.n && throw(DimensionMismatch("Pushed too many columns to matrix"))
-    !sortcol && partialsort!(s.cosorter, s.colptr[s.colcounter]:s.rowvalcounter)
+    if sortcol
+        s.cosorter.offset = s.colptr[s.colcounter] - 1
+        sort!(s.cosorter)
+    end
     s.colcounter += 1
     s.colptr[s.colcounter] = s.rowvalcounter
     return nothing

--- a/src/system_methods.jl
+++ b/src/system_methods.jl
@@ -451,7 +451,7 @@ function _growhamiltonian(sys::System{E,L,T,Tv}, supercell::SMatrix{L,L2}, sitem
                     end
                 end
                 colsdone += 1
-                finalisecolumn!(opbuilder.intra.matrixbuilder)
+                finalisecolumn!(opbuilder.intra.matrixbuilder, false) # sorts column
                 foreach(block -> finalisecolumn!(block.matrixbuilder), opbuilder.inters)
             end
         end

--- a/src/system_methods.jl
+++ b/src/system_methods.jl
@@ -443,7 +443,8 @@ function _growhamiltonian(sys::System{E,L,T,Tv}, supercell::SMatrix{L,L2}, sitem
                     newblock = get_or_add_blockbuilder(opbuilder, newndist, colsdone)
                     for ptr in ptrs
                         site, orb, s1 = tosite(rows[ptr], sys.sysinfo)
-                        checkbounds(Bool, sitemaps[s1], site, Tuple(wrappedndist)...) || continue
+                        checkbounds(Bool, sitemaps[s1], site, Tuple(wrappedndist)...) || 
+                            continue
                         newsitedest = sitemaps[s1][site, Tuple(wrappedndist)...]
                         iszero(newsitedest) && continue
                         row = torow(newsitedest, s1, newsysinfo) + orb
@@ -451,7 +452,7 @@ function _growhamiltonian(sys::System{E,L,T,Tv}, supercell::SMatrix{L,L2}, sitem
                     end
                 end
                 colsdone += 1
-                finalisecolumn!(opbuilder.intra.matrixbuilder, false) # sorts column
+                finalisecolumn!(opbuilder.intra.matrixbuilder, true) # true = sorts column
                 foreach(block -> finalisecolumn!(block.matrixbuilder), opbuilder.inters)
             end
         end

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -51,11 +51,14 @@ end
 # tuplesort(::Missing) = missing
 
 collectfirst(s::T, ss...) where {T} = _collectfirst((s,), ss...)
-_collectfirst(ts::NTuple{N,T}, s::T, ss...) where {N,T} = _collectfirst((ts..., s), ss...)
+_collectfirst(ts::NTuple{N,T}, s::T, ss...) where {N,T} = 
+    _collectfirst((ts..., s), ss...)
 _collectfirst(ts::Tuple, ss...) = (ts, ss)
-_collectfirst(ts::NTuple{N,System}, s::System, ss...) where {N} = _collectfirst((ts..., s), ss...)
+_collectfirst(ts::NTuple{N,System}, s::System, ss...) where {N} = 
+    _collectfirst((ts..., s), ss...)
 
+## Work around BUG: -SVector{0,Int}() isa SVector{0,Union{}}
 negSVector(s::SVector{L,<:Number}) where {L} = -s
-negSVector(s::SVector{0,<:Number}) where {L} = s    ## Work around BUG: -SVector{0,Int}() isa SVector{0,Union{}}
+negSVector(s::SVector{0,<:Number}) where {L} = s    
 
 allorderedpairs(v) = [(i, j) for i in v, j in v if i >= j]


### PR DESCRIPTION
Addresses #7 

There is about a 7% performance penalty of column sorting in `grow`. The advantage in linear algebra operations of sorted sparse columns seems non-existant.