### PR TITLE
Bravais with generic type

### DIFF
--- a/src/convert.jl
+++ b/src/convert.jl
@@ -29,8 +29,8 @@ Sublat{E,T}(s::Sublat) where {E,T} =
 Base.promote_rule(::Type{Sublat{E1,T1}}, ::Type{Sublat{E2,T2}}) where {E1,E2,T1,T2} = 
     Sublat{max(E1, E2), promote_type(T1, T2)}
 
-Bravais{E,L}(b::Bravais) where {E,L} = 
-    Bravais(padrightbottom(b.matrix, SMatrix{E,L,Float64}))
+Bravais{E,L,T}(b::Bravais) where {E,L,T} = 
+    Bravais(padrightbottom(b.matrix, SMatrix{E,L,T}))
 
 System{E,L,T,Tv}(s::System) where {E,L,T,Tv} = 
     System(convert(Lattice{E,L,T,Tv}, s.lattice), Operator{Tv,L}(s.hamiltonian))

--- a/src/lattice.jl
+++ b/src/lattice.jl
@@ -76,9 +76,9 @@ to match `E` and `T` from `sublats`. To override the embedding  dimension `E`, u
 
 # Examples
 ```jldoctest
-julia> Lattice(Bravais((1, 0)), Sublat((0, 0.)); dim = Val(3))
-Lattice{2,1,Float64}: 1-dimensional lattice with 1 Float64-typed sublattice in 2-dimensional 
-embedding space
+julia> Lattice(Bravais((1, 0)), Sublat((0, 0.)), Sublat((0, Float32(1))); dim = Val(3))
+Lattice{3,1,Float64}: 1-dimensional lattice with 2 Float64-typed sublattices in 
+3-dimensional embedding space
 ```
 """
 mutable struct Lattice{E,L,T,EL}  # mutable: Lattice transform needs to change bravais

--- a/src/system.jl
+++ b/src/system.jl
@@ -6,9 +6,9 @@
 
 Build a `System{E,L,T,Tv}` of `L` dimensions in `E`-dimensional embedding
 space and composed of `T`-typed sites and `Tv`-typed Hamiltonian. See
-`Sublat`, `Bravais` and `Model` for syntax.  To indicate a specific embedding 
-dimension `E`, use keyword `dim = Val(E)`. Similarly override types `T` and `Tv` 
-with `ptype = T` and `htype = Tv`.
+`Sublat`, `Bravais` and `Model` for syntax.  To override the embedding dimension `E`, use 
+keyword `dim = Val(E)`. Similarly, override types `T` and `Tv` with `ptype = T` and 
+`htype = Tv`.
 
     System(presetname::$(NameType)[, model]; kw...)
 

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -54,6 +54,7 @@ collectfirst(s::T, ss...) where {T} = _collectfirst((s,), ss...)
 _collectfirst(ts::NTuple{N,T}, s::T, ss...) where {N,T} = _collectfirst((ts..., s), ss...)
 _collectfirst(ts::Tuple, ss...) = (ts, ss)
 _collectfirst(ts::NTuple{N,System}, s::System, ss...) where {N} = _collectfirst((ts..., s), ss...)
+# collectfirsttolast(ss...) = tuplejoin(reverse(collectfirst(ss...))...)
 
 negSVector(s::SVector{L,<:Number}) where {L} = -s
 negSVector(s::SVector{0,<:Number}) where {L} = s    ## Work around BUG: -SVector{0,Int}() isa SVector{0,Union{}}

--- a/test/test_lattice.jl
+++ b/test/test_lattice.jl
@@ -4,9 +4,9 @@ using Test
 using Elsa
 using Elsa: nsites, nlinks
 
-@test Bravais() isa Bravais{0,0,0}
-@test Bravais((1,2),(3,3)) isa Bravais{2,2,4}
-@test Bravais(@SMatrix[1. 2.; 3 3]) isa Bravais{2,2,4}
+@test Bravais() isa Bravais{0,0,Float64,0}
+@test Bravais((1,2),(3,3)) isa Bravais{2,2,Int,4}
+@test Bravais(@SMatrix[1. 2.; 3 3]) isa Bravais{2,2,Float64,4}
 
 @test Sublat((3, 3)) isa Sublat{2,Int64}
 @test Sublat((3, 3.)) isa Sublat{2,Float64}

--- a/test/test_lattice.jl
+++ b/test/test_lattice.jl
@@ -5,7 +5,7 @@ using Elsa
 using Elsa: nsites, nlinks
 
 @test Bravais() isa Bravais{0,0,Float64,0}
-@test Bravais((1,2),(3,3)) isa Bravais{2,2,Int,4}
+@test Bravais((1, 2), (3, 3)) isa Bravais{2,2,Int,4}
 @test Bravais(@SMatrix[1. 2.; 3 3]) isa Bravais{2,2,Float64,4}
 
 @test Sublat((3, 3)) isa Sublat{2,Int64}
@@ -22,5 +22,15 @@ using Elsa: nsites, nlinks
 
 @test Sublat(@SVector[3f0, 3f0], (3, 4), name = :A) isa Sublat{2,Float32}
 @test Sublat((3f0, 3.0), name = :A) isa Sublat{2,Float64}
+
+@test_throws InexactError Lattice(Bravais((1, 2.2)), Sublat((1, 2)))
+@test Lattice(Bravais((1, 2.2)), Sublat((1, 2)), ptype = Float32) isa Lattice{2,1,Float32}
+
+@test Lattice(Bravais((1, 2)), Sublat((1, 2))) isa Lattice{2,1,Int}
+@test Lattice(Bravais((1, 2)), Sublat((1, 2.)), Sublat((2, 1))) isa Lattice{2,1,Float64}
+@test Lattice(Bravais((1, 2)), Sublat((1, 2.)), Sublat((2, 1)); dim = Val(3)) isa Lattice{3,1,Float64}
+@test Lattice(Bravais((1, 2)), Sublat((1, 2.)), Sublat((2, 1)); dim = Val(1)) isa Lattice{1,1,Float64}
+@test Lattice(Bravais((1, 2)), Sublat((1, 2.)), Sublat((2, 1)); dim = Val(3), ptype = Float32) isa Lattice{3,1,Float32}
+@test Lattice(Sublat((1, 2.))) isa Lattice{2,0,Float64}
 
 end # module

--- a/test/test_lattice.jl
+++ b/test/test_lattice.jl
@@ -18,8 +18,6 @@ using Elsa: nsites, nlinks
 @test Sublat((3, 4.), [3, 3]) isa Sublat{2,Float64}
 @test Sublat(@SVector[3f0, 3f0]) isa Sublat{2,Float32}
 
-# @test Sublat(Elsa.cartesian([3,4.], [3,3], 1:3)) isa Sublat{Float64,3}
-
 @test Sublat(@SVector[3f0, 3f0], (3, 4), name = :A) isa Sublat{2,Float32}
 @test Sublat((3f0, 3.0), name = :A) isa Sublat{2,Float64}
 


### PR DESCRIPTION
Closes #11

The type `T` of `Bravais` vectors is now generic and will be converted to match the type `T` of `Sublat`s.