### PR TITLE
Indexing and assignment for Hamiltonian

### DIFF
--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -275,8 +275,9 @@ Parametric Hamiltonian{<:Lattice} : 2D Hamiltonian on a 2D Lattice in 2D space
 
 ```
 """
-hamiltonian(lat, t1, ts...; orbitals = missing, kw...) =
-    _hamiltonian(lat, sanitize_orbs(orbitals, lat.unitcell.names), t1, ts...; kw...)
+hamiltonian(lat, ts...; orbitals = missing, kw...) =
+    _hamiltonian(lat, sanitize_orbs(orbitals, lat.unitcell.names), ts...; kw...)
+_hamiltonian(lat::AbstractLattice, orbs; kw...) = _hamiltonian(lat, orbs, TightbindingModel(); kw...)
 _hamiltonian(lat::AbstractLattice, orbs, m::TightbindingModel; type::Type = Complex{numbertype(lat)}, kw...) =
     hamiltonian_sparse(blocktype(orbs, type), lat, orbs, m; kw...)
 _hamiltonian(lat::AbstractLattice, orbs, m::TightbindingModel, f::Function;

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -175,7 +175,7 @@ sanitize_orbs(p::Pair) = sanitize_orbs(last(p))
 
 # External API #
 """
-    hamiltonian(lat, model; orbitals, field, type)
+    hamiltonian(lat[, model]; orbitals, field, type)
 
 Create a `Hamiltonian` by additively applying `model::TighbindingModel` to the lattice `lat`
 (see `hopping` and `onsite` for details on building tightbinding models).

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -335,6 +335,13 @@ function Base.deleteat!(h::Hamiltonian{<:Any,L}, dn::SVector{L,Int}) where {L}
     return h
 end
 
+Base.isassigned(h::Hamiltonian{<:Any,L}, dn::Vararg{Int,L}) where {L} = isassigned(h, dn)
+function Base.isassigned(h::Hamiltonian{<:Any,L}, dn::NTuple{L,Int}) where {L}
+    dnv = SVector(dn...)
+    nh = findfirst(hh -> hh.dn == dnv, h.harmonics)
+    return nh !== nothing
+end
+
 #######################################################################
 # auxiliary types
 #######################################################################


### PR DESCRIPTION
Closes #24 
Implements a variant of https://github.com/pablosanjose/Elsa.jl/issues/22#issuecomment-538051652

With this we can directly access the `HamiltonianHarmonic` matrix of `h::Hamiltonian` with `h[n1, n2,...]` where the n tuple is an integer cell distance (Harmonic vector, called `dn` in ELSA)

To add new (empty) harmonics do `push!(h, dn)`. If it is already present, h will not be modified. (dn can be a tuple, a splatted tuple or an `SVector`)

To check if a harmonic is present do `isassigned(h, dn)`

To delete a harmonic do `deleteat!(h, dn)`

To assign an element `i,j` in harmonic `dn` do `h[dn][i,j] = value`

Broadcasting is allowed, so that `h[dn...][is, js] .= value_matrix`, to enable bulk assignment without intermediate allocations (at least if `h` is dense - a sparse matrix will typically require internal reshuffling to insert new elements).