### PR TITLE
Redesigned bloch(hamiltonian)

### DIFF
--- a/src/Elsa.jl
+++ b/src/Elsa.jl
@@ -7,7 +7,8 @@ import Base: convert, iterate, ==, tail
 import SparseArrays: sparse!, mul!, getcolptr
 
 export sublat, bravais, lattice, hopping, onsite, hamiltonian, randomstate,
-       mul!, supercell, unitcell, semibounded, bloch, bloch!, sites
+       mul!, supercell, unitcell, semibounded, bloch, bloch!, optimize!,
+       sites
     #    unitlattice, combine, transform, transform!, bound,
     #    sitepositions, neighbors, bravaismatrix, marchingmesh
 # export MomentaKPM, dosKPM

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -653,8 +653,8 @@ omitted, the intracell Hamiltonian is returned instead.
 
 A suitable, non-initialized `matrix` can be obtained with `similar(h)`.
 
-If `optimize!(h)` is called before the first call to `bloch!`, performance will increase by
-avoiding memory reshuffling.
+If `optimize!(h)` is called on a sparse Hamiltonian `h` before the first call to `bloch!`,
+performance will increase by avoiding memory reshuffling.
 
 # Examples
 ```
@@ -720,8 +720,8 @@ Hamiltonian is returned instead.
 Functional forms of `bloch`, equivalent to `bloch(h, phases...)`
 
 This function allocates a new matrix on each call. For a non-allocating version of `bloch`,
-see `bloch!`. If `optimize!(h)` is called before the first call to `bloch`, performance will
-increase by avoiding memory reshuffling.
+see `bloch!`. If `optimize!(h)` is called on a sparse Hamiltonian `h` before the first call
+to `bloch`, performance will increase by avoiding memory reshuffling.
 
 # Examples
 ```


### PR DESCRIPTION
Avoid carrying an internal work matrix in Hamiltonian, in favor of the more Julian `bloch!(similar(h), h, phases...)`. The method `bloch!(h, phases...)` has been removed.

`Base.similar(::Hamiltonian)` is defined to return an uninitialized matrix, of the same type as the Hamiltonian's Matrix.

A new API method `optimize!(h)` is introduce to prepare a sparse `h` for optimal `bloch` computations by injecting structural the appropriate structural zeros in the base harmonic. Hence
```
optimize!(h)
bloch!(similar(h), h, ϕs...)
```
will be considerably faster (often several times) than without the `optimize!` call.