### PR TITLE
Implement mul! functionality for Supercell states

### DIFF
--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -33,7 +33,6 @@ Hamiltonian(lat::AbstractLattice, hs, field, orbs) =
 
 Base.show(io::IO, ham::Hamiltonian) = show(io, MIME("text/plain"), ham)
 function Base.show(io::IO, ::MIME"text/plain", ham::Hamiltonian)
-    slat = issuperlattice(ham.lattice)
     i = get(io, :indent, "")
     print(io, i, summary(ham), "\n",
 "$i  Bloch harmonics  : $(length(ham.harmonics)) ($(displaymatrixtype(ham)))

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -28,8 +28,6 @@ function Hamiltonian(lat, hs::Vector{H}, field, orbs, n::Int, m::Int) where {L,M
     end
     return Hamiltonian(lat, hs, field, orbs)
 end
-Hamiltonian(lat::AbstractLattice, hs, field, orbs) =
-    Hamiltonian(lat, hs, field, orbs)
 
 Base.show(io::IO, ham::Hamiltonian) = show(io, MIME("text/plain"), ham)
 function Base.show(io::IO, ::MIME"text/plain", ham::Hamiltonian)

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -88,10 +88,6 @@ _blocktype(::Type{S}) where {S<:Number} = S
 
 blocktype(h::Hamiltonian{LA,L,M}) where {LA,L,M} = M
 
-isnumblocktype(h::Hamiltonian) = isnumblocktype(blocktype(h))
-isnumblocktype(h::Number) = true
-isnumblocktype(h) = false
-
 function nhoppings(ham::Hamiltonian)
     count = 0
     for h in ham.harmonics

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -33,6 +33,7 @@ Hamiltonian(lat::AbstractLattice, hs, field, orbs) =
 
 Base.show(io::IO, ham::Hamiltonian) = show(io, MIME("text/plain"), ham)
 function Base.show(io::IO, ::MIME"text/plain", ham::Hamiltonian)
+    slat = issuperlattice(ham.lattice)
     i = get(io, :indent, "")
     print(io, i, summary(ham), "\n",
 "$i  Bloch harmonics  : $(length(ham.harmonics)) ($(displaymatrixtype(ham)))
@@ -42,6 +43,8 @@ $i  Element type     : $(displayelements(ham))
 $i  Onsites          : $(nonsites(ham))
 $i  Hoppings         : $(nhoppings(ham))
 $i  Coordination     : $(nhoppings(ham) / nsites(ham))")
+    ioindent = IOContext(io, :indent => string("  "))
+    issuperlattice(ham.lattice) && print(ioindent, "\n", ham.lattice.supercell)
 end
 
 Base.show(io::IO, h::HamiltonianHarmonic) = show(io, MIME("text/plain"), h)
@@ -475,7 +478,6 @@ isnotredundant((s1, s2)::Tuple{Int,Int}, term) = term.sublats !== missing && s1 
 #######################################################################
 # unitcell/supercell for Hamiltonians
 #######################################################################
-
 function supercell(ham::Hamiltonian, args...; kw...)
     slat = supercell(ham.lattice, args...; kw...)
     return Hamiltonian(slat, ham.harmonics, ham.field, ham.orbitals)
@@ -642,14 +644,30 @@ Base.eltype(::ParametricHamiltonian{H}) where {L,M,H<:Hamiltonian{L,M}} = M
 #######################################################################
 # Bloch routines
 #######################################################################
+struct SupercellBloch{L,T,M,H<:Hamiltonian{<:Superlattice,L,M}}
+    hamiltonian::H
+    phases::SVector{L,T}
+end
+
+Base.summary(h::SupercellBloch{L,T,M}) where {L,T,M} =
+    "SupercellBloch{$L,$(eltype(M))}: Bloch Hamiltonian matrix lazily defined on a supercell"
+
+function Base.show(io::IO, sb::SupercellBloch)
+    ioindent = IOContext(io, :indent => string("  "))
+    print(io, summary(sb), "\n  Phases          : $(Tuple(sb.phases))\n")
+    print(ioindent, sb.hamiltonian.lattice.supercell)
+end
+
 """
-    bloch!(matrix, h::Hamiltonian, ϕs::Real...)
-    bloch!(matrix, h::Hamiltonian, ϕs::NTuple{L,Real})
-    bloch!(matrix, h::Hamiltonian, ϕs::AbstractVector{Real})
+    bloch!(matrix, h::Hamiltonian{<:Lattice}, ϕs::Real...)
+    bloch!(matrix, h::Hamiltonian{<:Lattice}, ϕs::NTuple{L,Real})
+    bloch!(matrix, h::Hamiltonian{<:Lattice}, ϕs::AbstractVector{Real})
 
 Overwrite `matrix` with the Bloch Hamiltonian matrix of `h`, for the specified Bloch
 phases `ϕs`. In terms of Bloch wavevector `k`, `ϕs = k * bravais(h)`. If all `ϕs` are
-omitted, the intracell Hamiltonian is returned instead.
+omitted, the intracell Hamiltonian is returned instead. If the Hamiltonian is defined on a
+`Superlattice`, the evaluation of the Bloch Hamiltonian is deferred until it is used (e.g.
+in a multiplication).
 
 A suitable, non-initialized `matrix` can be obtained with `similar(h)`.
 
@@ -669,10 +687,12 @@ julia> LatticePresets.honeycomb() |> hamiltonian(onsite(1), hopping(2)) |> bloch
 # See also:
     bloch, optimize!
 """
-function bloch!(matrix::A, h::Hamiltonian{LA,L,M,A}, ϕs...) where {LA,L,M,A}
+function bloch!(matrix::A, h::Hamiltonian{<:Lattice,L,M,A}, ϕs...) where {L,M,A}
     copy!(matrix, first(h.harmonics).h)
     return add_harmonics!(matrix, h, ϕs...)
 end
+
+bloch(h::Hamiltonian{<:Superlattice}, ϕs...) = SupercellBloch(h, toSVector(ϕs))
 
 add_harmonics!(zerobloch, h::Hamiltonian, ϕs::Number...) =
     add_harmonics!(zerobloch, h, toSVector(ϕs))
@@ -706,22 +726,28 @@ function add_harmonics!(zerobloch::A, h::Hamiltonian{<:Lattice,L,M,A}, phases::S
 end
 
 """
-    bloch(h::Hamiltonian, phases::Real...)
-    bloch(h::Hamiltonian, phases::NTuple{L,Real})
-    bloch(h::Hamiltonian, phases::AbstractVector{Real})
+    bloch(h::Hamiltonian{<:Lattice}, ϕs::Real...)
+    bloch(h::Hamiltonian{<:Lattice}, ϕs::NTuple{L,Real})
+    bloch(h::Hamiltonian{<:Lattice}, ϕs::AbstractVector{Real})
 
-Build the Bloch Hamiltonian matrix of `h`, for the specified Bloch `phases`. In terms of
-Bloch wavevector `k`, `phases = k * bravais(h)`. If all `ϕs` are omitted, the intracell
-Hamiltonian is returned instead.
+Build the Bloch Hamiltonian matrix of `h`, for the specified Bloch phases `ϕs`. In terms of
+Bloch wavevector `k`, `ϕs = k * bravais(h)`. If all `ϕs` are omitted, the intracell
+Hamiltonian is returned instead. If the Hamiltonian is defined on a `Superlattice`, the
+evaluation of the Bloch Hamiltonian is deferred until it is used (e.g. in a multiplication).
 
-    h |> bloch(phases...)
-    h(phases...)
+    h |> bloch(ϕs...)
+    h(ϕs...)
 
-Functional forms of `bloch`, equivalent to `bloch(h, phases...)`
+Functional forms of `bloch`, equivalent to `bloch(h, ϕs...)`
 
 This function allocates a new matrix on each call. For a non-allocating version of `bloch`,
 see `bloch!`. If `optimize!(h)` is called on a sparse Hamiltonian `h` before the first call
 to `bloch`, performance will increase by avoiding memory reshuffling.
+
+    bloch(h::Hamiltonian{<:Superlattice}, ϕs...)
+
+Build a `SupercellBloch` object that lazily implements the Bloch Hamiltonian in the
+`Superlattice` without actually building the matrix (e.g. for matrix-free diagonalization).
 
 # Examples
 ```
@@ -737,7 +763,7 @@ julia> LatticePresets.honeycomb() |> hamiltonian(onsite(1), hopping(2)) |> bloch
     bloch!
 """
 bloch(phases...) = h -> bloch(h, phases...)
-bloch(h::Hamiltonian, phases...) = bloch!(similar(h), h, phases...)
+bloch(h::Hamiltonian{<:Lattice}, phases...) = bloch!(similar(h), h, phases...)
 
 """
     similar(h::Hamiltonian)
@@ -750,12 +776,15 @@ Base.similar(h::Hamiltonian) = similar(h.harmonics[1].h)
     optimize!(h::Hamiltonian)
 
 Prepare a sparse Hamiltonian `h` to increase the performance of subsequent calls to
-`bloch(h, ϕs...)` and `bloch!(matrix, h, ϕs...)` by minimizing memory reshufflings
+`bloch(h, ϕs...)` and `bloch!(matrix, h, ϕs...)` by minimizing memory reshufflings.
+
+No optimization will be performed on non-sparse Hamiltonians, or those defined on
+`Superlattice`s, for which Bloch Hamiltonians are lazily evaluated.
 
 # See also:
     bloch, bloch!
 """
-function optimize!(ham::Hamiltonian{LA,L,M,A}) where {LA,L,M,A<:SparseMatrixCSC}
+function optimize!(ham::Hamiltonian{<:Lattice,L,M,A}) where {LA,L,M,A<:SparseMatrixCSC}
     Tv = eltype(M)
     h0 = first(ham.harmonics)
     n, m = size(h0.h)
@@ -778,8 +807,13 @@ function optimize!(ham::Hamiltonian{LA,L,M,A}) where {LA,L,M,A<:SparseMatrixCSC}
     return ham
 end
 
-function optimize!(ham::Hamiltonian{LA,L,M,A}) where {LA,L,M,A<:AbstractMatrix}
+function optimize!(ham::Hamiltonian{<:Lattice,L,M,A}) where {LA,L,M,A<:AbstractMatrix}
     @warn "Hamiltonian is not sparse. Nothing changed."
+    return ham
+end
+
+function optimize!(ham::Hamiltonian{<:Superlattice})
+    @warn "Hamiltonian is defined on a Superlattice. Nothing changed."
     return ham
 end
 

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -643,13 +643,13 @@ Base.eltype(::ParametricHamiltonian{H}) where {L,M,H<:Hamiltonian{L,M}} = M
 #######################################################################
 # Bloch routines
 #######################################################################
-struct SupercellBloch{L,T,M,H<:Hamiltonian{<:Superlattice,L,M}}
+struct SupercellBloch{L,T,H<:Hamiltonian{<:Superlattice}}
     hamiltonian::H
     phases::SVector{L,T}
 end
 
-Base.summary(h::SupercellBloch{L,T,M}) where {L,T,M} =
-    "SupercellBloch{$L,$(eltype(M))}: Bloch Hamiltonian matrix lazily defined on a supercell"
+Base.summary(h::SupercellBloch{L,T}) where {L,T} =
+    "SupercellBloch{$L)}: Bloch Hamiltonian matrix lazily defined on an $(L)D supercell"
 
 function Base.show(io::IO, sb::SupercellBloch)
     ioindent = IOContext(io, :indent => string("  "))
@@ -697,8 +697,9 @@ add_harmonics!(zerobloch, h::Hamiltonian, ϕs::Number...) =
     add_harmonics!(zerobloch, h, toSVector(ϕs))
 add_harmonics!(zerobloch, h::Hamiltonian, ϕs::Tuple) =
     add_harmonics!(zerobloch, h, toSVector(ϕs))
-add_harmonics!(zerobloch, h::Hamiltonian, ::SVector{0}) = zerobloch
 
+add_harmonics!(zerobloch::A, h::Hamiltonian{<:Lattice,L,M,A}, ϕs::SVector{0}) where {L,M,A<:SparseMatrixCSC} =
+    zerobloch
 function add_harmonics!(zerobloch::A, h::Hamiltonian{<:Lattice,L,M,A}, ϕs::SVector{L}) where {L,M,A<:SparseMatrixCSC}
     for ns in 2:length(h.harmonics)
         hh = h.harmonics[ns]

--- a/src/lattice.jl
+++ b/src/lattice.jl
@@ -275,6 +275,9 @@ $i  Supersites    : $(nsites(s))", hassemi ? "
 $i  Semibounded   : $(display_as_tuple(findall(s.semibounded)))" : "")
 end
 
+ismasked(s::Supercell{L,L´,<:OffsetArray})  where {L,L´} = true
+ismasked(s::Supercell{L,L´,Missing})  where {L,L´} = false
+
 isinmask(s::Supercell{L,L´,<:OffsetArray}, site, dn) where {L,L´} = s.mask[site, Tuple(dn)...]
 isinmask(s::Supercell{L,L´,Missing}, site, dn) where {L,L´} = true
 isinmask(s::Supercell{L,L´,<:OffsetArray}, site) where {L,L´} = s.mask[site]
@@ -352,6 +355,9 @@ nsublats(lat::AbstractLattice) = length(lat.unitcell.names)
 
 issuperlattice(lat::Lattice) = false
 issuperlattice(lat::Superlattice) = true
+
+ismasked(lat::Lattice) = false
+ismasked(lat::Superlattice) = ismasked(lat.supercell)
 
 # External API #
 

--- a/src/lattice.jl
+++ b/src/lattice.jl
@@ -359,6 +359,9 @@ issuperlattice(lat::Superlattice) = true
 ismasked(lat::Lattice) = false
 ismasked(lat::Superlattice) = ismasked(lat.supercell)
 
+maskranges(lat::Superlattice) = (1:nsites(lat), lat.supercell.cells.indices...)
+maskranges(lat::Lattice) = (1:nsites(lat),)
+
 # External API #
 
 """

--- a/src/state.jl
+++ b/src/state.jl
@@ -102,15 +102,14 @@ function SparseArrays.mul!(t::S, hb::SupercellBloch, s::S, α::Number = true, β
         β != 0 ? rmul!(C, β) : fill!(C, zeroV)
     end
     # Add α * blochphase * h * source to target
-    #@inbounds Threads.@threads 
-    for ic in cells
+    @inbounds Threads.@threads for ic in cells
         i = Tuple(ic)
         # isemptycell(s, i) && continue # good for performance? Doesn't seem so
         for h in ham.harmonics
             olddn = h.dn + SVector(i)
             newdn = new_dn(olddn, pinvint)
             j = Tuple(wrap_dn(olddn, newdn, s.supercell.matrix))
-            j in cells || continue # boundaries in unwrapped directions
+            CartesianIndex(j) in cells || continue # boundaries in unwrapped directions
             α´ = α * cis(phases' * newdn)
             nzv = nonzeros(h.h)
             rv = rowvals(h.h)

--- a/src/state.jl
+++ b/src/state.jl
@@ -1,51 +1,31 @@
-# #######################################################################
-# # SupercellState
-# #######################################################################
-# struct SupercellBloch{L,T,M,H<:Hamiltonian{<:Superlattice,L,M}}
-#     hamiltonian::H
-#     phases::SVector{L,T}
-# end
-
-# Base.summary(h::SupercellBloch{L,T,M}) where {L,T,M} =
-#     "SupercellBloch{$L,$(eltype(M))}: Bloch Hamiltonian matrix lazily defined on a supercell"
-
-# function Base.show(io::IO, sb::SupercellBloch)
-#     ioindent = IOContext(io, :indent => string("  "))
-#     print(io, summary(sb), "\n  Phases          : $(Tuple(sb.phases))\n")
-#     print(ioindent, sb.hamiltonian.lattice.supercell)
-# end
-
 #######################################################################
 # SupercellState
 #######################################################################
-struct SupercellState{V,S<:Union{Missing,Supercell},A<:OffsetArray{V}}
+struct SupercellState{V,S<:Supercell,A<:OffsetArray{V}}
     vector::A
     supercell::S
 end
 
 SupercellState(lat::Superlattice{E,L,T};
       type::Type{Tv} = Complex{T},
-      vector = OffsetArray{orbitaltype(lat, Tv)}(undef, cellmaskaxes(lat))) where {E,L,T,Tv} =
+      vector = OffsetArray{orbitaltype(lat, Tv)}(undef, maskranges(lat))) where {E,L,T,Tv} =
     SupercellState(vector, lat.supercell)
 
-cellmaskaxes(lat::Superlattice{E,L}) where {E,L} = axes(lat.supercell.mask)
-cellmaskaxes(lat::Lattice{E,L}) where {E,L} = (1:nsites(lat),)
+maskranges(lat::Superlattice{E,L}) where {E,L} = (1:nsites(lat), lat.supercell.cells.indices...)
+maskranges(lat::Lattice{E,L}) where {E,L} = (1:nsites(lat),)
 
-nsites(s::SupercellState) = nsites(s.supercell)
+displayeltype(s::SupercellState{V}) where {V<:Number} = V
+displayeltype(s::SupercellState{V}) where {T,N,V<:SVector{N,T}} = T
 
-function isemptycell(s::SupercellState, cell)
-    @inbounds for i in size(s.supercell.mask, 1)
-        s.supercell.mask[i, cell...] && return false
-    end
-    return true
-end
+displayorbsize(s::SupercellState{V}) where {V<:Number} = 1
+displayorbsize(s::SupercellState{V}) where {T,N,V<:SVector{N,T}} = N
 
-Base.show(io::IO, s::SupercellState{V,S}) where {N,Tv,V<:SVector{N,Tv},L,L´,S<:Supercell{L,L´}} =
+Base.show(io::IO, s::SupercellState{V,S}) where {V,L,L´,S<:Supercell{L,L´}} =
     print(io,
 "SupercellState{$L} : state of an $(L)D Superlattice
-  Element type     : $Tv
-  Max orbital size : $N
-  Sites            : $(nsites(s))")
+  Element type     : $(displayeltype(s))
+  Max orbital size : $(displayorbsize(s))
+  Sites            : $(nsites(s.supercell))")
 
 Base.copy!(t::S, s::S) where {S<:SupercellState} = SupercellState(copy!(t.vector, s.vector), s.supercell)
 Base.copy(s::SupercellState) = SupercellState(copy(s.vector), s.supercell)
@@ -54,17 +34,18 @@ Base.similar(s::SupercellState) = SupercellState(similar(s.vector),  s.supercell
 # External API #
 
 # build a random state, with zeroed-out padding orbitals, throughout the supercell/unitcell
-function randomstate(lat::AbstractLattice{E,L,T}; type::Type{Tv} = Complex{T}) where {E,L,T,Tv}
-    isslat = issuperlattice(lat)
-    V = orbitaltype(lat, type)
+function randomstate(h::Hamiltonian{LA}; type::Type{Tv} = Complex{T}) where {E,L,T,Tv,LA<:AbstractLattice{E,L,T}}
+    lat = h.lattice
+    masked = ismasked(lat)
+    V = orbitaltype(h.orbitals, type)
     n, N = floatsorbs(V, T)
-    masksize = length.(cellmaskaxes(lat))
-    norbs = length.(lat.unitcell.orbitals)
+    masksize = length.(maskranges(lat))
+    norbs = length.(h.orbitals)
     v = rand(T, n * N, masksize...) # for performance, use n×N Floats to build an S
     if !all(x -> x == norbs[1], norbs)  # zero out missing orbitals
         @inbounds for c in CartesianIndices(masksize)
             site = first(Tuple(c))
-            insupercell = !isslat || lat.supercell.mask.parent[c]
+            insupercell = !masked || lat.supercell.mask.parent[c]
             norb = norbs[sublat(lat, site)] * insupercell
             for j in 1:N, i in 1:n
                 v[i + (j-1)*n, Tuple(c)...] =
@@ -132,7 +113,7 @@ function floatsorbs(V::Type{<:Number}, T)
 end
 
 function maybe_wrapstate(sv, lat::Superlattice)
-    o = OffsetArray(sv, cellmaskaxes(lat))
+    o = OffsetArray(sv, maskranges(lat))
     return SupercellState(o, lat.supercell)
 end
 maybe_wrapstate(sv, lat::Lattice) = sv
@@ -175,4 +156,12 @@ maybe_wrapstate(sv, lat::Lattice) = sv
 #         @inbounds isinmask(s.supercell, j) || (t.vector[j] = zeroV)
 #     end
 #     return t
+# end
+
+# function isemptycell(s::SupercellState, cell)
+#     ismasked(s.supercell) && return false
+#     @inbounds for i in size(s.supercell.mask, 1)
+#         s.supercell.mask[i, cell...] && return false
+#     end
+#     return true
 # end

--- a/src/state.jl
+++ b/src/state.jl
@@ -124,11 +124,3 @@ function SparseArrays.mul!(t::S, hb::SupercellBloch, s::S, α::Number = true, β
     end
     return t
 end
-
-# function isemptycell(s::SupercellState, cell)
-#     ismasked(s.supercell) || return false
-#     @inbounds for i in size(s.supercell.mask, 1)
-#         s.supercell.mask[i, cell...] && return false
-#     end
-#     return true
-# end

--- a/src/state.jl
+++ b/src/state.jl
@@ -1,19 +1,19 @@
-#######################################################################
-# SupercellState
-#######################################################################
-struct SupercellBloch{L,T,M,H<:Hamiltonian{<:Superlattice,L,M}}
-    hamiltonian::H
-    phases::SVector{L,T}
-end
+# #######################################################################
+# # SupercellState
+# #######################################################################
+# struct SupercellBloch{L,T,M,H<:Hamiltonian{<:Superlattice,L,M}}
+#     hamiltonian::H
+#     phases::SVector{L,T}
+# end
 
-Base.summary(h::SupercellBloch{L,T,M}) where {L,T,M} =
-    "SupercellBloch{$L,$(eltype(M))}: Bloch Hamiltonian matrix lazily defined on a supercell"
+# Base.summary(h::SupercellBloch{L,T,M}) where {L,T,M} =
+#     "SupercellBloch{$L,$(eltype(M))}: Bloch Hamiltonian matrix lazily defined on a supercell"
 
-function Base.show(io::IO, sb::SupercellBloch)
-    ioindent = IOContext(io, :indent => string("  "))
-    print(io, summary(sb), "\n  Phases          : $(Tuple(sb.phases))\n")
-    print(ioindent, sb.hamiltonian.lattice.supercell)
-end
+# function Base.show(io::IO, sb::SupercellBloch)
+#     ioindent = IOContext(io, :indent => string("  "))
+#     print(io, summary(sb), "\n  Phases          : $(Tuple(sb.phases))\n")
+#     print(ioindent, sb.hamiltonian.lattice.supercell)
+# end
 
 #######################################################################
 # SupercellState

--- a/src/state.jl
+++ b/src/state.jl
@@ -104,7 +104,7 @@ function SparseArrays.mul!(t::S, hb::SupercellBloch, s::S, α::Number = true, β
     # Add α * blochphase * h * source to target
     Threads.@threads for ic in cells
         i = Tuple(ic)
-        # isemptycell(s, i) && continue # good for performance? Doesn't seem so
+        # isemptycell(s, i) && continue # good for performance? No much
         for h in ham.harmonics
             olddn = h.dn + SVector(i)
             newdn = new_dn(olddn, pinvint)
@@ -128,10 +128,10 @@ function SparseArrays.mul!(t::S, hb::SupercellBloch, s::S, α::Number = true, β
     return t
 end
 
-function isemptycell(s::SupercellState, cell)
-    ismasked(s.supercell) && return false
-    @inbounds for i in size(s.supercell.mask, 1)
-        s.supercell.mask[i, cell...] && return false
-    end
-    return true
-end
+# function isemptycell(s::SupercellState, cell)
+#     ismasked(s.supercell) || return false
+#     @inbounds for i in size(s.supercell.mask, 1)
+#         s.supercell.mask[i, cell...] && return false
+#     end
+#     return true
+# end

--- a/src/state.jl
+++ b/src/state.jl
@@ -11,9 +11,6 @@ SupercellState(lat::Superlattice{E,L,T};
       vector = OffsetArray{orbitaltype(lat, Tv)}(undef, maskranges(lat))) where {E,L,T,Tv} =
     SupercellState(vector, lat.supercell)
 
-maskranges(lat::Superlattice{E,L}) where {E,L} = (1:nsites(lat), lat.supercell.cells.indices...)
-maskranges(lat::Lattice{E,L}) where {E,L} = (1:nsites(lat),)
-
 displayeltype(s::SupercellState{V}) where {V<:Number} = V
 displayeltype(s::SupercellState{V}) where {T,N,V<:SVector{N,T}} = T
 

--- a/src/state.jl
+++ b/src/state.jl
@@ -102,7 +102,7 @@ function SparseArrays.mul!(t::S, hb::SupercellBloch, s::S, α::Number = true, β
         β != 0 ? rmul!(C, β) : fill!(C, zeroV)
     end
     # Add α * blochphase * h * source to target
-    @inbounds Threads.@threads for ic in cells
+    Threads.@threads for ic in cells
         i = Tuple(ic)
         # isemptycell(s, i) && continue # good for performance? Doesn't seem so
         for h in ham.harmonics
@@ -114,9 +114,9 @@ function SparseArrays.mul!(t::S, hb::SupercellBloch, s::S, α::Number = true, β
             nzv = nonzeros(h.h)
             rv = rowvals(h.h)
             for col in cols
-                αxj = B[col, i...] * α´
+                @inbounds αxj = B[col, i...] * α´
                 for p in nzrange(h.h, col)
-                    C[rv[p], j...] += applyfield(ham.field, nzv[p], rv[p], col, h.dn) * αxj
+                    @inbounds C[rv[p], j...] += applyfield(ham.field, nzv[p], rv[p], col, h.dn) * αxj
                 end
             end
         end


### PR DESCRIPTION
Allows `mul!(t, h, s)`, where h is a `SupercellBloch` and `s,t` are `SupercellState`s. It's a lazy (matrix-free) version of the usual `Lattice` case, but for `Superlattice`