### PR TITLE
Bandstructure

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -6,6 +6,12 @@ git-tree-sha1 = "380e36c66edfa099cd90116b24c1ce8cafccac40"
 uuid = "621f4979-c628-5d54-868e-fcf4e3e8185c"
 version = "0.4.1"
 
+[[Arpack]]
+deps = ["BinaryProvider", "Libdl", "LinearAlgebra"]
+git-tree-sha1 = "07a2c077bdd4b6d23a40342a8a108e2ee5e58ab6"
+uuid = "7d9fca2a-8960-54d3-9f78-7d1dccf2cb97"
+version = "0.3.1"
+
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
@@ -62,6 +68,7 @@ uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 version = "0.21.0"
 
 [[LibGit2]]
+deps = ["Printf"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
 
 [[Libdl]]

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -68,7 +68,6 @@ uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 version = "0.21.0"
 
 [[LibGit2]]
-deps = ["Printf"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
 
 [[Libdl]]
@@ -114,7 +113,7 @@ uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
 version = "0.3.7"
 
 [[Pkg]]
-deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+deps = ["Dates", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [[Printf]]

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -23,9 +23,9 @@ version = "0.5.6"
 
 [[Compat]]
 deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
-git-tree-sha1 = "84aa74986c5b9b898b0d1acaf3258741ee64754f"
+git-tree-sha1 = "ed2c4abadf84c53d9e58510b5fc48912c2336fbb"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "2.1.0"
+version = "2.2.0"
 
 [[Conda]]
 deps = ["JSON", "VersionParsing"]
@@ -53,9 +53,9 @@ uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [[FFTW]]
 deps = ["AbstractFFTs", "BinaryProvider", "Conda", "Libdl", "LinearAlgebra", "Reexport", "Test"]
-git-tree-sha1 = "03f8776fbdae28c20c0d1d2ae4e090cd1dfcd247"
+git-tree-sha1 = "6c5b420da0b8c12098048561b8d58f81adea506f"
 uuid = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
-version = "1.0.0"
+version = "1.0.1"
 
 [[InteractiveUtils]]
 deps = ["Markdown"]
@@ -68,7 +68,6 @@ uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 version = "0.21.0"
 
 [[LibGit2]]
-deps = ["Printf"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
 
 [[Libdl]]
@@ -80,9 +79,9 @@ uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [[LinearMaps]]
 deps = ["LinearAlgebra", "SparseArrays"]
-git-tree-sha1 = "b32e88a3a99685a38780f5b31fc1e0af28f01477"
+git-tree-sha1 = "ecd59376591724b29db3728f54ee885ecbeb2395"
 uuid = "7a12625a-238d-50fd-b39a-03d52299707e"
-version = "2.5.1"
+version = "2.5.2"
 
 [[Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
@@ -114,7 +113,7 @@ uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
 version = "0.3.7"
 
 [[Pkg]]
-deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+deps = ["Dates", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [[Printf]]
@@ -123,9 +122,9 @@ uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [[ProgressMeter]]
 deps = ["Distributed", "Printf"]
-git-tree-sha1 = "0f08e0e74e5b160ca20d3962a2620038b75881c7"
+git-tree-sha1 = "fab12b19f198dd148ca467ac4e4f12ecd0241819"
 uuid = "92933f4c-e287-5a05-a399-4b506db050ca"
-version = "1.0.0"
+version = "1.1.0"
 
 [[REPL]]
 deps = ["InteractiveUtils", "Markdown", "Sockets"]

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -124,6 +124,8 @@ uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 [[ProgressMeter]]
 deps = ["Distributed", "Printf"]
 git-tree-sha1 = "fab12b19f198dd148ca467ac4e4f12ecd0241819"
+repo-rev = "master"
+repo-url = "https://github.com/timholy/ProgressMeter.jl.git"
 uuid = "92933f4c-e287-5a05-a399-4b506db050ca"
 version = "1.1.0"
 

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -68,6 +68,7 @@ uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 version = "0.21.0"
 
 [[LibGit2]]
+deps = ["Printf"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
 
 [[Libdl]]
@@ -113,7 +114,7 @@ uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
 version = "0.3.7"
 
 [[Pkg]]
-deps = ["Dates", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [[Printf]]
@@ -139,6 +140,12 @@ deps = ["Pkg"]
 git-tree-sha1 = "7b1d07f411bc8ddb7977ec7f377b97b158514fe0"
 uuid = "189a3867-3050-52da-a836-e630ba90ab69"
 version = "0.2.0"
+
+[[Requires]]
+deps = ["Test"]
+git-tree-sha1 = "f6fbf4ba64d295e146e49e021207993b6b48c7d1"
+uuid = "ae029012-a4dd-5104-9daa-d747884805df"
+version = "0.5.2"
 
 [[SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"

--- a/Project.toml
+++ b/Project.toml
@@ -3,10 +3,8 @@ uuid = "7d9ed76e-ca25-11e8-1412-8ff3848046c2"
 authors = ["Pablo San-Jose <lekand@gmail.com>"]
 version = "0.2.0"
 
-[compat]
-julia = "1.4"
-
 [deps]
+Arpack = "7d9fca2a-8960-54d3-9f78-7d1dccf2cb97"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LinearMaps = "7a12625a-238d-50fd-b39a-03d52299707e"
@@ -15,3 +13,6 @@ OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+
+[compat]
+julia = "1.4"

--- a/Project.toml
+++ b/Project.toml
@@ -15,4 +15,4 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-julia = "1.4"
+julia = "1.0"

--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ LinearMaps = "7a12625a-238d-50fd-b39a-03d52299707e"
 NearestNeighbors = "b8a86587-4115-5ab1-83bc-aa920d37bbce"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 

--- a/src/Elsa.jl
+++ b/src/Elsa.jl
@@ -21,6 +21,7 @@ export sublat, bravais, lattice, hopping, onsite, hamiltonian, randomstate,
 export LatticePresets, RegionPresets
 
 export @SMatrix, @SVector, SMatrix, SVector
+export ishermitian
 
 const NameType = Symbol
 const nametype = Symbol

--- a/src/Elsa.jl
+++ b/src/Elsa.jl
@@ -16,7 +16,7 @@ using StaticArrays, NearestNeighbors, SparseArrays, LinearAlgebra, OffsetArrays,
 
 export sublat, bravais, lattice, hopping, onsite, hamiltonian, randomstate,
        mul!, supercell, unitcell, semibounded, bloch, bloch!, optimize!, similarmatrix,
-       sites, bandstructure
+       sites, bandstructure, marchingmesh
 
 export LatticePresets, RegionPresets
 

--- a/src/Elsa.jl
+++ b/src/Elsa.jl
@@ -1,6 +1,7 @@
 module Elsa
 
-using StaticArrays, NearestNeighbors, SparseArrays, LinearAlgebra, OffsetArrays
+using StaticArrays, NearestNeighbors, SparseArrays, LinearAlgebra, OffsetArrays,
+      ProgressMeter
       #FFTW, ProgressMeter, FillArrays
 
 export sublat, bravais, lattice, hopping, onsite, hamiltonian, randomstate,
@@ -27,8 +28,8 @@ include("state.jl")
 # include("system.jl")
 # include("system_methods.jl")
 # include("KPM.jl")
-# include("mesh.jl")
-# include("bandstructure.jl")
+include("mesh.jl")
+include("bandstructure.jl")
 include("convert.jl")
 include("tools.jl")
 

--- a/src/Elsa.jl
+++ b/src/Elsa.jl
@@ -1,11 +1,21 @@
 module Elsa
 
+using Requires
+
+function __init__()
+    @require Pardiso = "46dd5b70-b6fb-5a00-ae2d-e8fea33afaf2" include("diagonalizers/pardiso.jl")
+    @require KrylovKit = "0b1a1467-8014-51b9-945f-bf0ae24f4b77" include("diagonalizers/krylovkit.jl")
+    @require Arpack = "7d9fca2a-8960-54d3-9f78-7d1dccf2cb97" include("diagonalizers/arpack.jl")
+    @require ArnoldiMethod = "ec485272-7323-5ecc-a04f-4719b315124d" include("diagonalizers/arnoldimethod.jl")
+    @require IterativeSolvers = "42fd0dbc-a981-5370-80f2-aaf504508153" include("diagonalizers/iterativesolvers.jl")
+end
+
 using StaticArrays, NearestNeighbors, SparseArrays, LinearAlgebra, OffsetArrays,
-      ProgressMeter, Arpack
-      #FFTW, ProgressMeter, FillArrays
+      ProgressMeter
+      #FFTW
 
 export sublat, bravais, lattice, hopping, onsite, hamiltonian, randomstate,
-       mul!, supercell, unitcell, semibounded, bloch, bloch!, optimize!,
+       mul!, supercell, unitcell, semibounded, bloch, bloch!, optimize!, similarmatrix,
        sites, bandstructure
 
 export LatticePresets, RegionPresets
@@ -28,6 +38,7 @@ include("state.jl")
 # include("system.jl")
 # include("system_methods.jl")
 # include("KPM.jl")
+include("diagonalizer.jl")
 include("mesh.jl")
 include("bandstructure.jl")
 include("convert.jl")

--- a/src/Elsa.jl
+++ b/src/Elsa.jl
@@ -1,12 +1,12 @@
 module Elsa
 
 using StaticArrays, NearestNeighbors, SparseArrays, LinearAlgebra, OffsetArrays,
-      ProgressMeter
+      ProgressMeter, Arpack
       #FFTW, ProgressMeter, FillArrays
 
 export sublat, bravais, lattice, hopping, onsite, hamiltonian, randomstate,
        mul!, supercell, unitcell, semibounded, bloch, bloch!, optimize!,
-       sites
+       sites, bandstructure
 
 export LatticePresets, RegionPresets
 

--- a/src/bandstructure.jl
+++ b/src/bandstructure.jl
@@ -40,7 +40,7 @@ end
 bandstructure(h::Hamiltonian{<:Any, L}, mesh = marchingmesh(ntuple(_ -> 10, Val(L))); kw...) where {L} =
     bandstructure!(diagonalizer(h; kw...), h, mesh) # barrier for type-unstable diagonalizer
 
-function bandstructure!(d::Diagnoalizer, h::Hamiltonian{<:Lattice,<:Any,M}, mesh::MD) where {M,D,MD<:Mesh{D}}
+function bandstructure!(d::Diagonalizer, h::Hamiltonian{<:Lattice,<:Any,M}, mesh::MD) where {M,D,MD<:Mesh{D}}
     T = eltype(M)
     nϵ = levels === missing ? size(h, 1) : levels
     dimh = size(h, 1)

--- a/src/diagonalizer.jl
+++ b/src/diagonalizer.jl
@@ -1,0 +1,79 @@
+#######################################################################
+# Diagonalizer
+#######################################################################
+abstract type DiagonalizeMethod end
+
+struct Diagonalizer{M<:DiagonalizeMethod,A<:AbstractArray,O<:NamedTuple,L,C,E}
+    method::M
+    matrix::A
+    codiag::C       # Matrix to resolve degeneracies
+end
+
+Diagonalizer(method, matrix) = Diagonalizer(method, matrix, missing)
+
+# This is in general type unstable, a function barrier when using it is needed
+diagonalizer(h::Hamiltonian{<:Lattice,<:Any,<:Any,<:Matrix}; kw...) =
+    diagonalizer(LinearAlgebraMethod(values(kw)), similarmatrix(h))
+
+function diagonalizer(h::Hamiltonian{<:Lattice,<:Any,M,<:SparseMatrixCSC};
+                      levels = missing, kw...) where {M}
+    if size(h, 1) < 50 || levels === missing
+        @warn "Requesting significant fraction of levels of sparse matrix. Converting to dense."
+        matrix = Matrix(similarmatrix(h))
+        wrappedmatrix = ishermitian(h) ? Hermitian(matrix) : matrix
+        return diagonalizer(LinearAlgebraMethod(; kw...), wrappedmatrix)
+    elseif M isa Number
+        return diagonalizer(ArpackMethod(; kw...), similarmatrix(h))
+    else
+        return diagonalizer(ArpackMethod(; kw...), similarmatrix(h))
+    end
+    throw(ArgumentError("Could not establish diagonalizer method"))
+end
+
+resolve_degeneracies!(ϵ, ψ, codiag::Missing) = (ϵ, ψ)
+
+#######################################################################
+# Diagonalize methods
+#   (All but LinearAlgebraMethod `@require` some package to be loaded)
+#######################################################################
+struct LinearAlgebraMethod{O} <: DiagonalizeMethod
+    options::O
+end
+
+LinearAlgebraMethod(; kw...) = LinearAlgebraMethod(values(kw))
+
+diagonalizer(method::LinearAlgebraMethod, matrix::Matrix) = Diagonalizer(method, matrix)
+
+function diagonalize(d::Diagonalizer{<:LinearAlgebraMethod}, degtol = )
+    ϵ, ψ = eigen!(d.matrix; d.options...)
+    resolve_degeneracies!(ϵ, ψ, d.codiag)
+    return ϵ, ψ
+end
+
+# Fallback for unloaded packages
+
+(m::DiagonalizeMethod)(;kw...) =
+    throw(ArgumentError("The package required for the requested diagonalize method $m is not loaded. Please do e.g. `using Arpack` to use the Arpack method. See `diagonalizer` for details."))
+
+# Optionally loaded methods
+
+struct ArpackMethod{O} <: DiagonalizeMethod
+    levels::Int
+    options::O
+end
+
+struct IterativeSolversMethod{O,L,E} <: DiagonalizeMethod
+    levels::Int
+    options::O
+    point::Float64  # Shift point for shift and invert
+    lmap::L         # LinearMap for shift and invert
+    engine::E       # Optional support for lmap (e.g. Pardiso solver or factorization)
+end
+
+struct KrylovKitMethod{O,L,E} <: DiagonalizeMethod
+    levels::Int
+    options::O
+    point::Float64  # Shift point for shift and invert
+    lmap::L         # LinearMap for shift and invert
+    engine::E       # Optional support for lmap (e.g. Pardiso solver or factorization)
+end

--- a/src/diagonalizer.jl
+++ b/src/diagonalizer.jl
@@ -1,77 +1,92 @@
 #######################################################################
 # Diagonalizer
 #######################################################################
-abstract type DiagonalizeMethod end
+abstract type DiagonalizePackage end
 
-struct Diagonalizer{M<:DiagonalizeMethod,A<:AbstractArray,O<:NamedTuple,L,C,E}
+struct Diagonalizer{M<:DiagonalizePackage,A<:AbstractArray,C}
     method::M
     matrix::A
-    codiag::C       # Matrix to resolve degeneracies
+    levels::Int
+    origin::Float64
+    minprojection::Float64
+    codiag::C       # Matrices to resolve degeneracies, or missing
 end
 
-Diagonalizer(method, matrix) = Diagonalizer(method, matrix, missing)
+function Diagonalizer(method, matrix::AbstractMatrix{M};
+             levels = missing,
+             origin = 0.0,
+             minprojection = 0.1,
+             codiag = missing) where {M}
+    _levels = levels === missing ? size(matrix, 1) : levels
+    Diagonalizer(method, matrix, _levels, origin, minprojection, codiag)
+end
 
 # This is in general type unstable, a function barrier when using it is needed
 diagonalizer(h::Hamiltonian{<:Lattice,<:Any,<:Any,<:Matrix}; kw...) =
-    diagonalizer(LinearAlgebraMethod(values(kw)), similarmatrix(h))
+    diagonalizer(LinearAlgebraPackage(values(kw)), similarmatrix(h))
 
 function diagonalizer(h::Hamiltonian{<:Lattice,<:Any,M,<:SparseMatrixCSC};
-                      levels = missing, kw...) where {M}
-    if size(h, 1) < 50 || levels === missing
-        @warn "Requesting significant fraction of levels of sparse matrix. Converting to dense."
+                      levels = missing, origin = 0.0, codiag = missing, kw...) where {M}
+    if size(h, 1) < 50 || levels === missing || levels / size(h, 1) > 0.1
+        # @warn "Requesting significant number of sparse matrix eigenvalues. Converting to dense."
         matrix = Matrix(similarmatrix(h))
-        wrappedmatrix = ishermitian(h) ? Hermitian(matrix) : matrix
-        return diagonalizer(LinearAlgebraMethod(; kw...), wrappedmatrix)
+        _matrix = ishermitian(h) ? Hermitian(matrix) : matrix
+        d = diagonalizer(LinearAlgebraPackage(; kw...), _matrix;
+            levels = levels, origin = origin, codiag = codiag)
     elseif M isa Number
-        return diagonalizer(ArpackMethod(; kw...), similarmatrix(h))
+        matrix = similarmatrix(h)
+        d = diagonalizer(ArpackPackage(; kw...), matrix;
+            levels = levels, origin = origin, codiag = codiag)
+    elseif M isa SMatrix
+        matrix = similarmatrix(h)
+        d = diagonalizer(ArnoldiPackagePackage(; kw...), matrix;
+            levels = levels, origin = origin, codiag = codiag)
     else
-        return diagonalizer(ArpackMethod(; kw...), similarmatrix(h))
+        throw(ArgumentError("Could not establish diagonalizer method"))
     end
-    throw(ArgumentError("Could not establish diagonalizer method"))
+    return d
 end
 
 resolve_degeneracies!(ϵ, ψ, codiag::Missing) = (ϵ, ψ)
 
 #######################################################################
 # Diagonalize methods
-#   (All but LinearAlgebraMethod `@require` some package to be loaded)
+#   (All but LinearAlgebraPackage `@require` some package to be loaded)
 #######################################################################
-struct LinearAlgebraMethod{O} <: DiagonalizeMethod
+struct LinearAlgebraPackage{O} <: DiagonalizePackage
     options::O
 end
 
-LinearAlgebraMethod(; kw...) = LinearAlgebraMethod(values(kw))
+LinearAlgebraPackage(; kw...) = LinearAlgebraPackage(values(kw))
 
-diagonalizer(method::LinearAlgebraMethod, matrix::Matrix) = Diagonalizer(method, matrix)
+# Registers method as available
+diagonalizer(method::LinearAlgebraPackage, matrix; kw...) = Diagonalizer(method, matrix; kw...)
 
-function diagonalize(d::Diagonalizer{<:LinearAlgebraMethod})
-    ϵ, ψ = eigen!(d.matrix; d.options...)
+function diagonalize(d::Diagonalizer{<:LinearAlgebraPackage})
+    ϵ, ψ = eigen!(d.matrix; sortby = λ -> abs(λ - d.origin), d.method.options...)
     resolve_degeneracies!(ϵ, ψ, d.codiag)
     return ϵ, ψ
 end
 
 # Fallback for unloaded packages
 
-(m::DiagonalizeMethod)(;kw...) =
+(m::DiagonalizePackage)(;kw...) =
     throw(ArgumentError("The package required for the requested diagonalize method $m is not loaded. Please do e.g. `using Arpack` to use the Arpack method. See `diagonalizer` for details."))
 
 # Optionally loaded methods
 
-struct ArpackMethod{O} <: DiagonalizeMethod
-    levels::Int
+struct ArpackPackage{O} <: DiagonalizePackage
     options::O
 end
 
-struct IterativeSolversMethod{O,L,E} <: DiagonalizeMethod
-    levels::Int
+struct IterativeSolversPackage{O,L,E} <: DiagonalizePackage
     options::O
     point::Float64  # Shift point for shift and invert
     lmap::L         # LinearMap for shift and invert
     engine::E       # Optional support for lmap (e.g. Pardiso solver or factorization)
 end
 
-struct KrylovKitMethod{O,L,E} <: DiagonalizeMethod
-    levels::Int
+struct ArnoldiPackagePackage{O,L,E} <: DiagonalizePackage
     options::O
     point::Float64  # Shift point for shift and invert
     lmap::L         # LinearMap for shift and invert

--- a/src/diagonalizer.jl
+++ b/src/diagonalizer.jl
@@ -44,7 +44,7 @@ LinearAlgebraMethod(; kw...) = LinearAlgebraMethod(values(kw))
 
 diagonalizer(method::LinearAlgebraMethod, matrix::Matrix) = Diagonalizer(method, matrix)
 
-function diagonalize(d::Diagonalizer{<:LinearAlgebraMethod}, degtol = )
+function diagonalize(d::Diagonalizer{<:LinearAlgebraMethod})
     ϵ, ψ = eigen!(d.matrix; d.options...)
     resolve_degeneracies!(ϵ, ψ, d.codiag)
     return ϵ, ψ

--- a/src/diagonalizer.jl
+++ b/src/diagonalizer.jl
@@ -1,9 +1,10 @@
 #######################################################################
 # Diagonalizer
 #######################################################################
-abstract type DiagonalizePackage end
+abstract type AbstractCodiagonalizer end
+abstract type AbstractDiagonalizePackage end
 
-struct Diagonalizer{M<:DiagonalizePackage,A<:AbstractArray,C}
+struct Diagonalizer{M<:AbstractDiagonalizePackage,A<:AbstractArray,C<:Union{Missing,AbstractCodiagonalizer}}
     method::M
     matrix::A
     levels::Int
@@ -50,20 +51,85 @@ end
 #######################################################################
 # Codiagonalization
 #######################################################################
-struct Codiagonalizer{H}
+struct VelocityCodiagonalizer{M,H<:Hamiltonian{<:Any,<:Any,M}} <: AbstractCodiagonalizer
     h::H
+    degeneracies::Vector{Int}
+end
+VelocityCodiagonalizer(h::Hamiltonian{<:Any,<:Any,M}) where {M} =
+    VelocityCodiagonalizer(h, Int[])
+
+# ϵ is assumed sorted
+resolve_degeneracies!(ϵ, ψ, codiag::Missing) = (ϵ, ψ)
+# function resolve_degeneracies!(ϵ, ψ, codiag::VelocityCodiagonalizer, ϕs::SVector{L}) where {L}
+#     degeneracies!(codiag.degeneracies, ϵ)
+# end
+
+function degeneracies!(deglist, ϵs)
+    resize!(deglist, 0)
+    l = length(ϵs)
+    if l > 1
+        for (i, ϵ) in enumerate(ϵs)
+            if (i > 1 && ϵ ≈ ϵs[i - 1]) || (i < l && ϵ ≈ ϵs[i + 1])
+                push!(deglist, i)
+            end
+        end
+    end
+    return deglist
 end
 
-resolve_degeneracies!(ϵ, ψ, codiag::Missing) = (ϵ, ψ)
-function resolve_degeneracies!(ϵ, ψ, codiag::Codiagonalizer{<:Hamiltonian})
-    
-end
+
+# function resolve_degeneracies!(energies, states, vfunc::Function, kn::SVector{L}, degtol) where {L}
+#     degsubspaces = degeneracies(energies, degtol)
+#     if !(degsubspaces === nothing)
+#         for subspaceinds in degsubspaces
+#             for axis = 1:L
+#                 v = vfunc(kn, axis)  # Need to do it in-place for each subspace
+#                 subspace = view(states, :, subspaceinds)
+#                 vsubspace = subspace' * v * subspace
+#                 veigen = eigen!(vsubspace)
+#                 subspace .= subspace * veigen.vectors
+#                 success = !hasdegeneracies(veigen.values, degtol)
+#                 success && break
+#             end
+#         end
+#     end
+#     return nothing
+# end
+
+# function hasdegeneracies(sorted_ϵ, degtol)
+#     for i in 2:length(sorted_ϵ)
+#         abs(sorted_ϵ[i] - sorted_ϵ[i-1]) < degtol && return true
+#     end
+#     return false
+# end
+
+# function degeneracies(energies, degtol)
+#     if hasdegeneracies(energies, degtol)
+#         deglist = Vector{Int}[]
+#         isclassified = BitArray(false for _ in eachindex(energies))
+#         for i in eachindex(energies)
+#             isclassified[i] && continue
+#             degeneracyfound = false
+#             for j in (i + 1):length(energies)
+#                 if !isclassified[j] && abs(energies[i] - energies[j]) < degtol
+#                     !degeneracyfound && push!(deglist, [i])
+#                     degeneracyfound = true
+#                     push!(deglist[end], j)
+#                     isclassified[j] = true
+#                 end
+#             end
+#         end
+#         return deglist
+#     else
+#         return nothing
+#     end
+# end
 
 #######################################################################
 # Diagonalize methods
 #   (All but LinearAlgebraPackage `@require` some package to be loaded)
 #######################################################################
-struct LinearAlgebraPackage{O} <: DiagonalizePackage
+struct LinearAlgebraPackage{O} <: AbstractDiagonalizePackage
     options::O
 end
 
@@ -74,29 +140,29 @@ diagonalizer(method::LinearAlgebraPackage, matrix; kw...) = Diagonalizer(method,
 
 function diagonalize(d::Diagonalizer{<:LinearAlgebraPackage})
     ϵ, ψ = eigen!(d.matrix; sortby = λ -> abs(λ - d.origin), d.method.options...)
-    resolve_degeneracies!(ϵ, ψ, d.codiag)
-    return ϵ, ψ
+    ϵ´, ψ´ = view(ϵ, 1:d.levels), view(ψ, :, 1:d.levels)
+    return ϵ´, ψ´
 end
 
 # Fallback for unloaded packages
 
-(m::DiagonalizePackage)(;kw...) =
+(m::AbstractDiagonalizePackage)(;kw...) =
     throw(ArgumentError("The package required for the requested diagonalize method $m is not loaded. Please do e.g. `using Arpack` to use the Arpack method. See `diagonalizer` for details."))
 
 # Optionally loaded methods
 
-struct ArpackPackage{O} <: DiagonalizePackage
+struct ArpackPackage{O} <: AbstractDiagonalizePackage
     options::O
 end
 
-struct IterativeSolversPackage{O,L,E} <: DiagonalizePackage
+struct IterativeSolversPackage{O,L,E} <: AbstractDiagonalizePackage
     options::O
     point::Float64  # Shift point for shift and invert
     lmap::L         # LinearMap for shift and invert
     engine::E       # Optional support for lmap (e.g. Pardiso solver or factorization)
 end
 
-struct ArnoldiPackagePackage{O,L,E} <: DiagonalizePackage
+struct ArnoldiPackagePackage{O,L,E} <: AbstractDiagonalizePackage
     options::O
     point::Float64  # Shift point for shift and invert
     lmap::L         # LinearMap for shift and invert

--- a/src/diagonalizer.jl
+++ b/src/diagonalizer.jl
@@ -47,7 +47,17 @@ function diagonalizer(h::Hamiltonian{<:Lattice,<:Any,M,<:SparseMatrixCSC};
     return d
 end
 
+#######################################################################
+# Codiagonalization
+#######################################################################
+struct Codiagonalizer{H}
+    h::H
+end
+
 resolve_degeneracies!(ϵ, ψ, codiag::Missing) = (ϵ, ψ)
+function resolve_degeneracies!(ϵ, ψ, codiag::Codiagonalizer{<:Hamiltonian})
+    
+end
 
 #######################################################################
 # Diagonalize methods

--- a/src/diagonalizers/arnoldimethod.jl
+++ b/src/diagonalizers/arnoldimethod.jl
@@ -1,0 +1,18 @@
+struct ArnoldiMethod_IRAM{Tv} <: AbstractEigenMethod{Tv}
+end
+
+(::Type{<:ArnoldiMethod_IRAM})(h::AbstractMatrix{Tv}) where {Tv} = ArnoldiMethod_IRAM{Tv}()
+
+function (d::Diagonalizer{<:ArnoldiMethod_IRAM,Tv})(nev::Integer; precond = false, kw...) where {Tv}
+    precond && @warn "ArnoldiMethod_IRAM does not yet support preconditioning"
+    if isfinite(d.point)
+        which = ArnoldiMethod.LM()
+    else
+        which = d.point > 0 ? ArnoldiMethod.LR() : ArnoldiMethod.SR()
+    end
+    decomp, _ = ArnoldiMethod.partialschur(d.lmap; nev = nev, which = which, kw...)
+    λs = real.(decomp.eigenvalues)
+    ϕs = decomp.Q
+    isfinite(d.point) && (λs .= 1 ./ λs .+ d.point)
+    return Eigen(λs, ϕs)
+end

--- a/src/diagonalizers/arpack.jl
+++ b/src/diagonalizers/arpack.jl
@@ -1,0 +1,34 @@
+# struct Arpack_IRAM{Tv} <: AbstractEigenMethod{Tv}
+#     precond::Vector{Tv}
+# end
+
+# (::Type{<:Arpack_IRAM})(h::AbstractMatrix{Tv}) where {Tv} = Arpack_IRAM(rand(Tv, size(h, 2)))
+
+# function (d::Diagonalizer{<:Arpack_IRAM,Tv})(nev::Integer; precond = true, kw...) where {Tv}
+#     if isfinite(d.point)
+#         which = :LM
+#         # sigma = real(Tv) === Tv ? d.point : d.point + 1.0im
+#         sigma = d.point
+#     elseif point > 0
+#         which = :LR
+#         sigma = nothing
+#     else
+#         which = :SR
+#         sigma = nothing
+#     end
+#     λs, ϕs, _ = Arpack.eigs(d.matrix; nev = nev, sigma = sigma, which = which, 
+#                              v0 = d.method.precond, kw...)
+#     if precond
+#         d.method.precond .= zero(Tv)
+#         foreach(ϕ -> (d.method.precond .+= ϕ), eachcol(ϕs))
+#     end
+#     return Eigen(real(λs), ϕs)
+# end
+
+ArpackMethod(; levels = 6, kw...) = ArpackMethod(levels, (nev = levels, values(kw)...))
+
+diagonalizer(method::ArpackMethod, matrix::SparseMatrixCSC) = Diagonalizer(method, matrix)
+
+function _spectrum(d::Diagonalizer{<:ArpackMethod})
+    
+end

--- a/src/diagonalizers/arpack.jl
+++ b/src/diagonalizers/arpack.jl
@@ -25,10 +25,11 @@
 #     return Eigen(real(λs), ϕs)
 # end
 
-ArpackMethod(; levels = 6, kw...) = ArpackMethod(levels, (nev = levels, values(kw)...))
+ArpackMethod(; levels = 6, kw...) = ArpackMethod((nev = levels, values(kw)...))
 
-diagonalizer(method::ArpackMethod, matrix::SparseMatrixCSC) = Diagonalizer(method, matrix)
+# Registers method as available
+diagonalizer(method::ArpackMethod, matrix; kw...) = Diagonalizer(method, matrix; kw...)
 
-function _spectrum(d::Diagonalizer{<:ArpackMethod})
-    
-end
+# function diagonalize(d::Diagonalizer{<:ArpackMethod})
+
+# end

--- a/src/diagonalizers/iterativesolvers.jl
+++ b/src/diagonalizers/iterativesolvers.jl
@@ -1,0 +1,21 @@
+struct IterativeSolvers_LOBPCG{Tv} <: AbstractEigenMethod{Tv}
+    precond::Matrix{Tv}
+    IterativeSolvers_LOBPCG{Tv}(h::AbstractMatrix{Tv}, nev = 1) where {Tv} = 
+        new(rand(Tv, size(h,1), nev))
+end
+
+IterativeSolvers_LOBPCG(h::AbstractMatrix{Tv}, nev = 1) where {Tv} = 
+    IterativeSolvers_LOBPCG{Tv}(h, nev)
+
+function (d::Diagonalizer{<:IterativeSolvers_LOBPCG, Tv})(nev::Integer; 
+        side = upper, precond = true, kw...) where {Tv}
+    if size(d.method.precond) != (size(d.matrix, 1), nev)
+        d.method = IterativeSolvers_LOBPCG(d.matrix, nev) # reset preconditioner
+    end
+    largest = ifelse(isfinite(d.point), side === upper , d.point > 0)
+    result = IterativeSolvers.lobpcg(d.lmap, largest, d.method.precond; kw...)
+    λs, ϕs = result.λ, result.X
+    isfinite(d.point) && (λs .= 1 ./ λs .+ d.point)
+    precond && foreach(i -> (d.method.precond[i] = ϕs[i]), eachindex(d.method.precond))
+    return Eigen(real(λs), ϕs)
+end

--- a/src/diagonalizers/krylovkit.jl
+++ b/src/diagonalizers/krylovkit.jl
@@ -1,0 +1,20 @@
+struct KrylovKit_IRAM{Tv} <: AbstractEigenMethod{Tv}
+    precond::Vector{Tv}
+end
+
+(::Type{<:KrylovKit_IRAM})(h::AbstractMatrix{Tv}) where {Tv} = KrylovKit_IRAM(rand(Tv, size(h, 2)))
+
+function (d::Diagonalizer{<:KrylovKit_IRAM, Tv})(nev::Integer; precond = true, kw...) where {Tv}
+    if isfinite(d.point)
+        λs, ϕv, _ = KrylovKit.eigsolve(x -> d.lmap * x, d.method.precond, nev; kw...)
+        λs .= 1 ./ λs .+ d.point
+    else
+        λs, ϕv, _ = KrylovKit.eigsolve(d.matrix, d.method.precond, nev, 
+                                       d.point > 0 ? :LR : :SR, Lanczos(kw...))
+    end
+    if precond
+        d.method.precond .= zero(Tv)
+        foreach(ϕ -> (d.method.precond .+= ϕ), ϕv)
+    end
+    return Eigen(real(λs), hcat(ϕv))
+end

--- a/src/diagonalizers/pardiso.jl
+++ b/src/diagonalizers/pardiso.jl
@@ -1,0 +1,70 @@
+ENV["OMP_NUM_THREADS"] = 4
+
+export PardisoShift
+
+struct PardisoShift
+    point::Float64
+    verbose::Bool
+end
+
+"""
+    PardisoShift(p::Number; verbose = false)
+
+When used as the `point = PardisoShift(p)` keyword argument in `diagonalize`, it forces use 
+of the MKL Pardiso library for the shift-and-invert Lanczos method (it should be installed). 
+`verbose = true` makes Pardiso verbose.
+
+# Example
+```jldoctest
+julia> using Pardiso, Arpack; h = rand(10,10); h = h' + h;
+
+julia> d = diagonalizer(h, Arpack_IRAM, point = PardisoShift(0.0))
+Diagonaliser{Arpack_IRAM{Float64}} for (10, 10) Hermitian matrix around point 0.0
+```
+"""
+PardisoShift(p::Number; verbose = false) = PardisoShift(p, verbose)
+
+getpoint(p::PardisoShift) = p.point
+
+function linearmap(h::AbstractArray{Tv}, p::PardisoShift) where {Tv}
+    ps = pardisosolver(;verbose = p.verbose)
+    _set_matrixtype!(ps, Tv)
+    hp = ensuresparse(Pardiso.get_matrix(ps, h - Tv(p.point) * I, :N))
+    preparesolver!(ps, hp)
+    lmap = let ps = ps, hp = hp
+        LinearMap{Tv}((x, b) -> Pardiso.pardiso(ps, x, hp, b), size(h)...,
+                      ismutating = true, ishermitian = true)
+    end
+    return lmap, ps
+end
+
+function pardisosolver(; verbose = false)
+    ps = Pardiso.MKLPardisoSolver()
+    finalizer(releasePardiso, ps)
+    verbose && Pardiso.set_msglvl!(ps, Pardiso.MESSAGE_LEVEL_ON)
+    Pardiso.pardisoinit(ps)
+    Pardiso.set_iparm!(ps, 12, 2) # Pardiso expects CSR, Julia uses CSC
+    return ps
+end
+
+_set_matrixtype!(ps, ::Type{<:AbstractFloat}) = Pardiso.set_matrixtype!(ps, Pardiso.REAL_SYM_INDEF)
+_set_matrixtype!(ps, ::Type{<:Complex}) = Pardiso.set_matrixtype!(ps, Pardiso.COMPLEX_HERM_INDEF)
+
+ensuresparse(a::SparseMatrixCSC) = a
+ensuresparse(a::AbstractMatrix) = sparse(a)
+
+function preparesolver!(ps, hp::AbstractArray{Tv}) where {Tv}
+    b = Vector{Tv}(undef, size(hp, 1))
+    Pardiso.set_phase!(ps, Pardiso.ANALYSIS_NUM_FACT)
+    Pardiso.pardiso(ps, hp, b)
+    Pardiso.set_phase!(ps, Pardiso.SOLVE_ITERATIVE_REFINE)
+    return ps
+end
+
+function releasePardiso(ps)
+    original_phase = Pardiso.get_phase(ps)
+    Pardiso.set_phase!(ps, Pardiso.RELEASE_ALL);
+    Pardiso.pardiso(ps)
+    Pardiso.set_phase!(ps, original_phase)
+    return ps
+end

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -701,11 +701,10 @@ bloch!(matrix, h, ϕs::Number...) = _bloch!(matrix, h, toSVector(ϕs), 0)
 bloch!(matrix, h, ϕs::Tuple, axis = 0) = _bloch!(matrix, h, toSVector(ϕs), axis)
 bloch!(matrix, h, ϕs::SVector, axis = 0) = _bloch!(matrix, h, ϕs, axis)
 
-_bloch!(matrix::Hermitian, h::Hamiltonian, ϕs, axis) =
+_bloch!(matrix::Hermitian, h::Hamiltonian{<:Lattice,L,M}, ϕs, axis) where {L,M} =
     (_bloch!(matrix.data, h, ϕs, axis); matrix)
 
-function _bloch!(matrix::AbstractMatrix{M}, h::Hamiltonian{<:Lattice,L,M,A},
-                 ϕs::SVector, axis) where {L,M,A}
+function _bloch!(matrix::AbstractMatrix, h::Hamiltonian{<:Lattice,L,M}, ϕs, axis) where {L,M}
     if iszero(axis)
         _copy!(matrix, first(h.harmonics).h) # faster copy!(dense, sparse) specialization
     else

--- a/src/mesh.jl
+++ b/src/mesh.jl
@@ -5,30 +5,33 @@
 abstract type AbstractMesh{D} end
 
 struct Mesh{D,V,S} <: AbstractMesh{D}   # D is dimension of parameter space
-    vertices::V                         # Iterable vertex container (generator, vector,...)
+    vertices::V                         # Iterable vertex container (generator, vector,...) -> SVector{E,T}
     adjmat::SparseMatrixCSC{Bool,Int}   # Directed graph: only dest > src
-    simplices::S                        # Iterable simplex container (generator, vector,...)
+    simplices::S                        # Iterable simplex container (generator, vector,...) -> NTuple{D+1,Int}
 end
 
 Mesh{D}(vertices::V, adjmat, simplices::S) where {D,V,S} = Mesh{D,V,S}(vertices, adjmat, simplices)
 
-Base.show(io::IO, mesh::Mesh{D}) where {D} = print(io,
-"Mesh{$D}: mesh in $D-dimensional space
-  Vertices  : $(nvertices(mesh))
-  Edges     : $(nedges(mesh))
-  Simplices : $(nsimplices(mesh))")
+function Base.show(io::IO, mesh::Mesh{D}) where {D}
+    i = get(io, :indent, "")
+    print(io,
+"$(i)Mesh{$D}: mesh of a $D-dimensional manifold
+$i  Vertices   : $(nvertices(mesh))
+$i  Edges      : $(nedges(mesh))
+$i  Simplices  : $(nsimplices(mesh))")
+end
 
-# nvertices(m::Mesh) = length(m.vertices)
+nvertices(m::Mesh) = length(m.vertices)
 
-# nsimplices(m::Mesh) = length(m.simplices)
+nsimplices(m::Mesh) = length(m.simplices)
 
-# nedges(m::Mesh) = nnz(m.adjmat)
+nedges(m::Mesh) = nnz(m.adjmat)
 
 vertices(m::Mesh) = m.vertices
 
 edges(m::Mesh, src) = nzrange(m.adjmat, src)
 
-destination(m::Mesh, edge) = rowvals(m.adjmat)[edge]
+edgedest(m::Mesh, edge) = rowvals(m.adjmat)[edge]
 
 
 ######################################################################

--- a/src/mesh.jl
+++ b/src/mesh.jl
@@ -10,7 +10,7 @@ struct Mesh{D,V,S} <: AbstractMesh{D}   # D is dimension of parameter space
     simplices::S                        # Iterable simplex container (generator, vector,...)
 end
 
-Mesh{D}(vertices::V, adjmat, simplices::GT) where {D,V,GT} = Mesh{D,V,GT}(vertices, adjmat, simplices)
+Mesh{D}(vertices::V, adjmat, simplices::S) where {D,V,S} = Mesh{D,V,S}(vertices, adjmat, simplices)
 
 Base.show(io::IO, mesh::Mesh{D}) where {D} = print(io,
 "Mesh{$D}: mesh in $D-dimensional space
@@ -18,11 +18,18 @@ Base.show(io::IO, mesh::Mesh{D}) where {D} = print(io,
   Edges     : $(nedges(mesh))
   Simplices : $(nsimplices(mesh))")
 
-nvertices(m::Mesh) = length(m.vertices)
+# nvertices(m::Mesh) = length(m.vertices)
 
-nsimplices(m::Mesh) = length(m.simplices)
+# nsimplices(m::Mesh) = length(m.simplices)
 
-nedges(m::Mesh) = nnz(m.adjmat)
+# nedges(m::Mesh) = nnz(m.adjmat)
+
+vertices(m::Mesh) = m.vertices
+
+edges(m::Mesh, src) = nzrange(m.adjmat, src)
+
+destination(m::Mesh, edge) = rowvals(m.adjmat)[edge]
+
 
 ######################################################################
 # Special meshes

--- a/src/mesh.jl
+++ b/src/mesh.jl
@@ -40,14 +40,14 @@ edgedest(m::Mesh, edge) = rowvals(m.adjmat)[edge]
 """
   marchingmesh(npoints::NTuple{D,Integer}[, box::SMatrix{D,D})
 
-Creates a D-dimensional marching-tetrahedra `Mesh`. The mesh is confined to the box defined 
+Creates a D-dimensional marching-tetrahedra `Mesh`. The mesh is confined to the box defined
 by the columns of `box`, and contains `npoints[i]` vertices along column i.
 
 # External links
 
 - Marching tetrahedra (https://en.wikipedia.org/wiki/Marching_tetrahedra) in Wikipedia
 """
-function marchingmesh(npoints::NTuple{D,Integer}, 
+function marchingmesh(npoints::NTuple{D,Integer},
                       box::SMatrix{D,D,T} = SMatrix{D,D,Float64}(I)) where {D,T<:AbstractFloat}
     projection = box ./ (SVector(npoints) - 1)' # Projects binary vector to m box with npoints
     cs = CartesianIndices(ntuple(n -> 1:npoints[n], Val(D)))

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -115,7 +115,7 @@ end
 
 # allorderedpairs(v) = [(i, j) for i in v, j in v if i >= j]
 
-# # Like copyto! but with potentially different tensor orders
+# # Like copyto! but with potentially different tensor orders (taken from Base.copyto!)
 # function copyslice!(dest::AbstractArray{T1,N1}, Rdest::CartesianIndices{N1},
 #                     src::AbstractArray{T2,N2}, Rsrc::CartesianIndices{N2}) where {T1,T2,N1,N2}
 #     isempty(Rdest) && return dest

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -101,6 +101,19 @@ end
 
 isnonnegative(ndist) = iszero(ndist) || ispositive(ndist)
 
+_copy!(dest, src) = copy!(dest, src)
+function _copy!(dst::Matrix{T}, src::SparseMatrixCSC) where {T}
+    axes(dst) == axes(src) || throw(ArgumentError(
+        "arrays must have the same axes for copy!"))
+    fill!(dst, zero(T))
+    for col in 1:size(src,1)
+        for p in nzrange(src, col)
+            dst[rowvals(src)[p], col] = nonzeros(src)[p]
+        end
+    end
+    return dst
+end
+
 # pinverse(s::SMatrix) = (qrfact = qr(s); return inv(qrfact.R) * qrfact.Q')
 
 # padrightbottom(m::Matrix{T}, im, jm) where {T} = padrightbottom(m, zero(T), im, jm)

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -91,6 +91,16 @@ function isgrowing(vs::AbstractVector, i0 = 1)
     return true
 end
 
+function ispositive(ndist)
+    result = false
+    for i in ndist
+        i == 0 || (result = i > 0; break)
+    end
+    return result
+end
+
+isnonnegative(ndist) = iszero(ndist) || ispositive(ndist)
+
 # pinverse(s::SMatrix) = (qrfact = qr(s); return inv(qrfact.R) * qrfact.Q')
 
 # padrightbottom(m::Matrix{T}, im, jm) where {T} = padrightbottom(m, zero(T), im, jm)
@@ -118,19 +128,19 @@ end
 # Like copyto! but with potentially different tensor orders (taken from Base.copyto!)
 function copyslice!(dest::AbstractArray{T1,N1}, Rdest::CartesianIndices{N1},
                     src::AbstractArray{T2,N2}, Rsrc::CartesianIndices{N2}) where {T1,T2,N1,N2}
-    # isempty(Rdest) && return dest
-    # if length(Rdest) != length(Rsrc)
-    #     throw(ArgumentError("source and destination must have same length (got $(length(Rsrc)) and $(length(Rdest)))"))
-    # end
-    # checkbounds(dest, first(Rdest))
-    # checkbounds(dest, last(Rdest))
-    # checkbounds(src, first(Rsrc))
-    # checkbounds(src, last(Rsrc))
-    # src′ = Base.unalias(dest, src)
-    # @inbounds for (Is, Id) in zip(Rsrc, Rdest)
-    #     @inbounds dest[Id] = src′[Is]
-    # end
-    # return dest
+    isempty(Rdest) && return dest
+    if length(Rdest) != length(Rsrc)
+        throw(ArgumentError("source and destination must have same length (got $(length(Rsrc)) and $(length(Rdest)))"))
+    end
+    checkbounds(dest, first(Rdest))
+    checkbounds(dest, last(Rdest))
+    checkbounds(src, first(Rsrc))
+    checkbounds(src, last(Rsrc))
+    src′ = Base.unalias(dest, src)
+    @inbounds for (Is, Id) in zip(Rsrc, Rdest)
+        @inbounds dest[Id] = src′[Is]
+    end
+    return dest
 end
 
 ######################################################################

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -115,23 +115,23 @@ end
 
 # allorderedpairs(v) = [(i, j) for i in v, j in v if i >= j]
 
-# # Like copyto! but with potentially different tensor orders (taken from Base.copyto!)
-# function copyslice!(dest::AbstractArray{T1,N1}, Rdest::CartesianIndices{N1},
-#                     src::AbstractArray{T2,N2}, Rsrc::CartesianIndices{N2}) where {T1,T2,N1,N2}
-#     isempty(Rdest) && return dest
-#     if length(Rdest) != length(Rsrc)
-#         throw(ArgumentError("source and destination must have same length (got $(length(Rsrc)) and $(length(Rdest)))"))
-#     end
-#     checkbounds(dest, first(Rdest))
-#     checkbounds(dest, last(Rdest))
-#     checkbounds(src, first(Rsrc))
-#     checkbounds(src, last(Rsrc))
-#     src′ = Base.unalias(dest, src)
-#     for (Is, Id) in zip(Rsrc, Rdest)
-#         @inbounds dest[Id] = src′[Is]
-#     end
-#     return dest
-# end
+# Like copyto! but with potentially different tensor orders (taken from Base.copyto!)
+function copyslice!(dest::AbstractArray{T1,N1}, Rdest::CartesianIndices{N1},
+                    src::AbstractArray{T2,N2}, Rsrc::CartesianIndices{N2}) where {T1,T2,N1,N2}
+    # isempty(Rdest) && return dest
+    # if length(Rdest) != length(Rsrc)
+    #     throw(ArgumentError("source and destination must have same length (got $(length(Rsrc)) and $(length(Rdest)))"))
+    # end
+    # checkbounds(dest, first(Rdest))
+    # checkbounds(dest, last(Rdest))
+    # checkbounds(src, first(Rsrc))
+    # checkbounds(src, last(Rsrc))
+    # src′ = Base.unalias(dest, src)
+    # @inbounds for (Is, Id) in zip(Rsrc, Rdest)
+    #     @inbounds dest[Id] = src′[Is]
+    # end
+    # return dest
+end
 
 ######################################################################
 # Permutations (taken from Combinatorics.jl)


### PR DESCRIPTION
This lays down the basic functionality to compute bandstructures. It computes eigenvalues and eigenvectors over a Brillouin zone mesh, and classifies them into subbands (using a most-parallel criterion between neighbors)

Missing functionality still:

- Resolve trivial degeneracies (at band crossings) using velocity operators
- Resolve nontrivial degeneracies (diabolical points) using vertex splitting
- Resolve band knots (simplices enclosing diabolical points) using energy sorting + refining