### PR TITLE
Introduce sitephases option in bloch/bloch!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - linux
   - osx
 julia:
-  - 1.4
+  - 1.3
   - nightly
 notifications:
   email: false

--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-julia = "1.0"
+julia = "1.3"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -118,7 +118,7 @@ function _copy!(dst::Matrix{T}, src::SparseMatrixCSC) where {T}
     return dst
 end
 
-# pinverse(s::SMatrix) = (qrfact = qr(s); return inv(qrfact.R) * qrfact.Q')
+pinverse(s::SMatrix) = (qrfact = qr(s); return inv(qrfact.R) * qrfact.Q')
 
 # padrightbottom(m::Matrix{T}, im, jm) where {T} = padrightbottom(m, zero(T), im, jm)
 


### PR DESCRIPTION
Closes #13 

This adds a `sitephases::Bool` kwarg to `bloch` and `bloch!` that implements convention 2 of #13 when true. I decided on the name `sitephases` since the phase is site-dependent

The performance of the `sitephases = false` is the same as before, but with `sitephases = true`, performance takes a substantial hit. This is not surprising, as one k-dependent phase has to be computed for each hopping and each harmonic, as opposed to one per harmonic.

```
julia> h = LatticePresets.honeycomb() |> unitcell(3) |> hamiltonian(onsite(1) + hopping(2)); optimize!(h);

julia> @btime bloch($h, (π,π), sitephases = false);
  1.411 μs (5 allocations: 4.83 KiB)

julia> @btime bloch($h, (π,π), sitephases = true);
  4.391 μs (5 allocations: 4.83 KiB)

julia> h = LatticePresets.honeycomb() |> unitcell(20) |> hamiltonian(onsite(1) + hopping(2)); optimize!(h);

julia> @btime bloch($h, (π,π), sitephases = false);
  24.080 μs (7 allocations: 194.16 KiB)

julia> @btime bloch($h, (π,π), sitephases = true);
  115.348 μs (7 allocations: 194.16 KiB)
```