### PR TITLE
Flattening Hamiltonians

### DIFF
--- a/src/Elsa.jl
+++ b/src/Elsa.jl
@@ -18,7 +18,7 @@ using SparseArrays: getcolptr
 
 export sublat, bravais, lattice, dims, hopping, onsite, hamiltonian, randomstate,
        mul!, supercell, unitcell, semibounded, bloch, bloch!, optimize!, similarmatrix,
-       sites, bandstructure, marchingmesh, defaultmethod
+       sites, bandstructure, marchingmesh, defaultmethod, flatten
 
 export LatticePresets, RegionPresets
 

--- a/src/bandstructure.jl
+++ b/src/bandstructure.jl
@@ -81,7 +81,7 @@ end
 
 function bandstructure(h::Hamiltonian, mesh::Mesh; method = defaultmethod(h), minprojection = 0.5)
     d = diagonalizer(h, mesh, method, minprojection)
-    matrix = similarmatrix(h,  d.method)
+    matrix = similarmatrix(h)
     return bandstructure!(matrix, h, mesh, d)
 end
 

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -856,12 +856,12 @@ end
 # Tested, it is slower
 
 function optimize!(ham::Hamiltonian{<:Lattice,L,M,A}) where {LA,L,M,A<:AbstractMatrix}
-    @warn "Hamiltonian is not sparse. Nothing changed."
+    # @warn "Hamiltonian is not sparse. Nothing changed."
     return ham
 end
 
 function optimize!(ham::Hamiltonian{<:Superlattice})
-    @warn "Hamiltonian is defined on a Superlattice. Nothing changed."
+    # @warn "Hamiltonian is defined on a Superlattice. Nothing changed."
     return ham
 end
 

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -871,7 +871,31 @@ end
 
 Flatten a multiorbital Hamiltonian `h` into one with a single orbital per site. The
 associated lattice is flattened also, so that there is one site per orbital for each initial
-site (all at the same position)
+site (all at the same position). Note that zeros in hopping/onsite matrices are preserved as
+structural zeros upon flattenin
+
+# Examples
+```
+julia> h = LatticePresets.honeycomb() |> hamiltonian(hopping(@SMatrix[1 2], range = 1/√3, sublats = (:A,:B)), orbitals = (Val(1), Val(2)))
+Hamiltonian{<:Lattice} : 2D Hamiltonian on a 2D Lattice in 2D space
+  Bloch harmonics  : 5 (SparseMatrixCSC, sparse)
+  Harmonic size    : 2 × 2
+  Orbitals         : ((:a,), (:a, :a))
+  Element type     : 2 × 2 blocks (Complex{Float64})
+  Onsites          : 0
+  Hoppings         : 6
+  Coordination     : 3.0
+
+julia> flatten(h)
+Hamiltonian{<:Lattice} : 2D Hamiltonian on a 2D Lattice in 2D space
+  Bloch harmonics  : 5 (SparseMatrixCSC, sparse)
+  Harmonic size    : 3 × 3
+  Orbitals         : ((:flat,), (:flat,))
+  Element type     : scalar (Complex{Float64})
+  Onsites          : 0
+  Hoppings         : 12
+  Coordination     : 4.0
+```
 """
 function flatten(h::Hamiltonian)
     all(isequal(1), norbitals(h)) && return copy(h)

--- a/src/model.jl
+++ b/src/model.jl
@@ -220,7 +220,6 @@ Base.:-(t::TightbindingModelTerm) = (-1) * t
 # Base.:+(t1::TightbindingModelTerm, t2::TightbindingModelTerm) = TightbindingModel((t1, t2))
 # Base.:-(t1::TightbindingModelTerm, t2::TightbindingModelTerm) = TightbindingModel((t1, -t2))
 
-
 #######################################################################
 # TightbindingModel
 #######################################################################


### PR DESCRIPTION
Ideally we want to be able to handle eltypes different from numbers in Hamiltonians, but that is somewhat tricky when calling sparse diagonalization matrices. Arpack for example is not pure Julia, and doesn't accept non-numeric eltypes

The simplest way out of this is to allow flattening a Hamiltonian with several orbitals per site into a Hamiltonian with a single orbital per site. This PR implements such a mechanism through the command `flatten`.