### PR TITLE
Refactored how complex eigenvalues are managed

### DIFF
--- a/src/Elsa.jl
+++ b/src/Elsa.jl
@@ -18,7 +18,7 @@ using SparseArrays: getcolptr
 
 export sublat, bravais, lattice, dims, hopping, onsite, hamiltonian, randomstate,
        mul!, supercell, unitcell, semibounded, bloch, bloch!, optimize!, similarmatrix,
-       sites, bandstructure, marchingmesh, defaultmethod
+       sites, bandstructure, marchingmesh, defaultmethod, flatten
 
 export LatticePresets, RegionPresets
 

--- a/src/bandstructure.jl
+++ b/src/bandstructure.jl
@@ -36,7 +36,7 @@ end
     bandstructure(h::Hamiltonian, mesh::Mesh; minprojection = 0.5, method = defaultmethod(h))
 
 Compute the bandstructure of Bloch Hamiltonian `bloch(h, ϕs...)` with `ϕs` evaluated on the
-vertices of `mesh`.
+vertices of `mesh`. It is assumed that `h` is hermitian.
 
 The option `minprojection` determines the minimum projection between eigenstates to connect
 them into a common subband. The option `method` is chosen automatically if unspecified, and
@@ -80,8 +80,9 @@ function bandstructure(h::Hamiltonian{<:Any,L,M}; resolution = 13, shift = missi
 end
 
 function bandstructure(h::Hamiltonian, mesh::Mesh; method = defaultmethod(h), minprojection = 0.5)
+    ishermitian(h) || throw(ArgumentError("Hamiltonian must be hermitian"))
     d = diagonalizer(h, mesh, method, minprojection)
-    matrix = similarmatrix(h)
+    matrix = Hermitian(similarmatrix(h))
     return bandstructure!(matrix, h, mesh, d)
 end
 

--- a/src/bandstructure.jl
+++ b/src/bandstructure.jl
@@ -81,7 +81,7 @@ end
 
 function bandstructure(h::Hamiltonian, mesh::Mesh; method = defaultmethod(h), minprojection = 0.5)
     d = diagonalizer(h, mesh, method, minprojection)
-    matrix = similarmatrix(h,  d.method)
+    matrix = similarmatrix(h)
     return bandstructure!(matrix, h, mesh, d)
 end
 

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -871,7 +871,31 @@ end
 
 Flatten a multiorbital Hamiltonian `h` into one with a single orbital per site. The
 associated lattice is flattened also, so that there is one site per orbital for each initial
-site (all at the same position)
+site (all at the same position). Note that zeros in hopping/onsite matrices are preserved as
+structural zeros upon flattenin
+
+# Examples
+```
+julia> h = LatticePresets.honeycomb() |> hamiltonian(hopping(@SMatrix[1 2], range = 1/√3, sublats = (:A,:B)), orbitals = (Val(1), Val(2)))
+Hamiltonian{<:Lattice} : 2D Hamiltonian on a 2D Lattice in 2D space
+  Bloch harmonics  : 5 (SparseMatrixCSC, sparse)
+  Harmonic size    : 2 × 2
+  Orbitals         : ((:a,), (:a, :a))
+  Element type     : 2 × 2 blocks (Complex{Float64})
+  Onsites          : 0
+  Hoppings         : 6
+  Coordination     : 3.0
+
+julia> flatten(h)
+Hamiltonian{<:Lattice} : 2D Hamiltonian on a 2D Lattice in 2D space
+  Bloch harmonics  : 5 (SparseMatrixCSC, sparse)
+  Harmonic size    : 3 × 3
+  Orbitals         : ((:flat,), (:flat,))
+  Element type     : scalar (Complex{Float64})
+  Onsites          : 0
+  Hoppings         : 12
+  Coordination     : 4.0
+```
 """
 function flatten(h::Hamiltonian)
     all(isequal(1), norbitals(h)) && return copy(h)

--- a/src/iterators.jl
+++ b/src/iterators.jl
@@ -248,7 +248,8 @@ function Base.sizehint!(s::SparseMatrixBuilder, n)
 end
 
 function pushtocolumn!(s::SparseMatrixBuilder, row::Int, x, skipdupcheck::Bool = true)
-    1 <= row <= size(s.matrix, 1) || throw(ArgumentError("tried adding a row $row out of bounds ($(size(s.matrix, 1)))"))
+    nrows = size(s.matrix, 1)
+    nrows == 0 || 1 <= row <= size(s.matrix, 1) || throw(ArgumentError("tried adding a row $row out of bounds ($(size(s.matrix, 1)))"))
     if skipdupcheck || !isintail(row, rowvals(s.matrix), getcolptr(s.matrix)[s.colcounter])
         push!(rowvals(s.matrix), row)
         push!(nonzeros(s.matrix), x)

--- a/src/model.jl
+++ b/src/model.jl
@@ -220,7 +220,6 @@ Base.:-(t::TightbindingModelTerm) = (-1) * t
 # Base.:+(t1::TightbindingModelTerm, t2::TightbindingModelTerm) = TightbindingModel((t1, t2))
 # Base.:-(t1::TightbindingModelTerm, t2::TightbindingModelTerm) = TightbindingModel((t1, -t2))
 
-
 #######################################################################
 # TightbindingModel
 #######################################################################


### PR DESCRIPTION
Hamiltonians are hermitian more often than not, but we don't enforce hermiticity anywhere. However, one place it is crucial is when computing bandstructures. To signal real eigenvalues we use the `similarmatrix(h)` mechanism when calling `bloch!`. By making it `Hermitian`, all diagonalizers know that they must return real eigenvalues. This PR makes `bandstructure` always call `bandstructure!(matrix, h,...)` with `matrix = Hermitian(similarmatrix(h))`, so that by default hermiticity is enforced in bandstructure calculations.