### PR TITLE
Another refactor of complex eigenvalue handling

### DIFF
--- a/src/bandstructure.jl
+++ b/src/bandstructure.jl
@@ -106,8 +106,6 @@ function bandstructure!(matrix::AbstractMatrix, h::Hamiltonian{<:Lattice,<:Any,M
             ϵks = Matrix{T}(undef, nϵ, nk)
             ψks = Array{M,3}(undef, dimh, nϵ, nk)
         end
-        @show ishermitian(matrix), typeof(matrix), ϕs
-        iszero(ϕs) && @show matrix[1:4, 1:4]
         copyslice!(ϵks, CartesianIndices((1:nϵ, n:n)),
                    ϵk,  CartesianIndices((1:nϵ,)), by)
         copyslice!(ψks, CartesianIndices((1:dimh, 1:nϵ, n:n)),

--- a/src/bandstructure.jl
+++ b/src/bandstructure.jl
@@ -82,7 +82,7 @@ end
 function bandstructure(h::Hamiltonian, mesh::Mesh; method = defaultmethod(h), minprojection = 0.5)
     ishermitian(h) || throw(ArgumentError("Hamiltonian must be hermitian"))
     d = diagonalizer(h, mesh, method, minprojection)
-    matrix = Hermitian(similarmatrix(h))
+    matrix = similarmatrix(h)
     return bandstructure!(matrix, h, mesh, d)
 end
 
@@ -105,9 +105,9 @@ function bandstructure!(matrix::AbstractMatrix, h::Hamiltonian{<:Lattice,<:Any,M
             ψks = Array{M,3}(undef, dimh, nϵ, nk)
         end
         copyslice!(ϵks, CartesianIndices((1:nϵ, n:n)),
-                   ϵk,  CartesianIndices((1:nϵ,)))
+                   ϵk,  CartesianIndices((1:nϵ,)), real)
         copyslice!(ψks, CartesianIndices((1:dimh, 1:nϵ, n:n)),
-                   ψk,  CartesianIndices((1:dimh, 1:nϵ)))
+                   ψk,  CartesianIndices((1:dimh, 1:nϵ)), identity)
         ProgressMeter.next!(p; showvalues = ())
     end
 

--- a/src/bandstructure.jl
+++ b/src/bandstructure.jl
@@ -106,6 +106,8 @@ function bandstructure!(matrix::AbstractMatrix, h::Hamiltonian{<:Lattice,<:Any,M
             ϵks = Matrix{T}(undef, nϵ, nk)
             ψks = Array{M,3}(undef, dimh, nϵ, nk)
         end
+        @show ishermitian(matrix), typeof(matrix), ϕs
+        iszero(ϕs) && @show matrix[1:4, 1:4]
         copyslice!(ϵks, CartesianIndices((1:nϵ, n:n)),
                    ϵk,  CartesianIndices((1:nϵ,)), by)
         copyslice!(ψks, CartesianIndices((1:dimh, 1:nϵ, n:n)),

--- a/src/bandstructure.jl
+++ b/src/bandstructure.jl
@@ -94,6 +94,8 @@ function bandstructure!(matrix::AbstractMatrix, h::Hamiltonian{<:Lattice,<:Any,M
     dimh = size(h, 1)
     nk = nvertices(mesh)
 
+    by = _maybereal(T)
+
     p = Progress(nk, "Step 1/2 - Diagonalising: ")
     for (n, ϕs) in enumerate(vertices(mesh))
         bloch!(matrix, h, ϕs)
@@ -105,7 +107,7 @@ function bandstructure!(matrix::AbstractMatrix, h::Hamiltonian{<:Lattice,<:Any,M
             ψks = Array{M,3}(undef, dimh, nϵ, nk)
         end
         copyslice!(ϵks, CartesianIndices((1:nϵ, n:n)),
-                   ϵk,  CartesianIndices((1:nϵ,)), real)
+                   ϵk,  CartesianIndices((1:nϵ,)), by)
         copyslice!(ψks, CartesianIndices((1:dimh, 1:nϵ, n:n)),
                    ψk,  CartesianIndices((1:dimh, 1:nϵ)), identity)
         ProgressMeter.next!(p; showvalues = ())
@@ -130,6 +132,9 @@ function bandstructure!(matrix::AbstractMatrix, h::Hamiltonian{<:Lattice,<:Any,M
     end
     return Bandstructure(bands, mesh)
 end
+
+_maybereal(::Type{<:Complex}) = identity
+_maybereal(::Type{<:Real}) = real
 
 function extractband(kmesh::Mesh{D,T}, pending, ϵks::AbstractArray{T}, ψks::AbstractArray{M}, vertindices, minprojection) where {D,T,M}
     dimh, nϵ, nk = size(ψks)

--- a/src/bandstructure.jl
+++ b/src/bandstructure.jl
@@ -82,7 +82,7 @@ end
 function bandstructure(h::Hamiltonian, mesh::Mesh; method = defaultmethod(h), minprojection = 0.5)
     ishermitian(h) || throw(ArgumentError("Hamiltonian must be hermitian"))
     d = diagonalizer(h, mesh, method, minprojection)
-    matrix = similarmatrix(h)
+    matrix = similarmatrix(h, method)
     return bandstructure!(matrix, h, mesh, d)
 end
 
@@ -94,7 +94,7 @@ function bandstructure!(matrix::AbstractMatrix, h::Hamiltonian{<:Lattice,<:Any,M
     dimh = size(h, 1)
     nk = nvertices(mesh)
 
-    by = _maybereal(T)
+    by = _maybereal(T)  # function to apply to eigenvalues when building bands
 
     p = Progress(nk, "Step 1/2 - Diagonalising: ")
     for (n, ϕs) in enumerate(vertices(mesh))

--- a/src/diagonalizer.jl
+++ b/src/diagonalizer.jl
@@ -26,9 +26,6 @@ end
 checkloaded(package::Symbol) = isdefined(Main, package) ||
     throw(ArgumentError("Package $package not loaded, need to be `using $package`."))
 
-maybereal(ϵ::Vector{<:Complex}, matrix::Hermitian) = real.(ϵ)
-maybereal(ϵ, matrix) = ϵ
-
 ## LinearAlgebra ##
 struct LinearAlgebraPackage{K<:NamedTuple} <: AbstractDiagonalizeMethod
     kw::K
@@ -38,8 +35,7 @@ LinearAlgebraPackage(; kw...) = LinearAlgebraPackage(values(kw))
 
 function diagonalize(matrix, d::Diagonalizer{<:LinearAlgebraPackage})
     ϵ, ψ = eigen!(matrix; (d.method.kw)...)
-    ϵ´ = maybereal(ϵ, matrix)
-    return ϵ´, ψ
+    return ϵ, ψ
 end
 
 ## Arpack ##
@@ -51,8 +47,7 @@ ArpackPackage(; kw...) = (checkloaded(:Arpack); ArpackPackage(values(kw)))
 
 function diagonalize(matrix, d::Diagonalizer{<:ArpackPackage})
     ϵ, ψ = Main.Arpack.eigs(matrix; (d.method.kw)...)
-    ϵ´ = maybereal(ϵ, matrix)
-    return ϵ´, ψ
+    return ϵ, ψ
 end
 
 ## IterativeSolvers ##

--- a/src/diagonalizer.jl
+++ b/src/diagonalizer.jl
@@ -38,6 +38,8 @@ function diagonalize(matrix, d::Diagonalizer{<:LinearAlgebraPackage})
     return ϵ, ψ
 end
 
+similarmatrix(h, ::LinearAlgebraPackage) = Matrix(similarmatrix(h))
+
 ## Arpack ##
 struct ArpackPackage{K<:NamedTuple} <: AbstractDiagonalizeMethod
     kw::K
@@ -49,6 +51,8 @@ function diagonalize(matrix, d::Diagonalizer{<:ArpackPackage})
     ϵ, ψ = Main.Arpack.eigs(matrix; (d.method.kw)...)
     return ϵ, ψ
 end
+
+similarmatrix(h, ::ArpackPackage) = similarmatrix(h)
 
 ## IterativeSolvers ##
 
@@ -80,6 +84,8 @@ function diagonalize(matrix::AbstractMatrix{M}, d::Diagonalizer{<:KrylovKitPacka
 
     return ϵ´, ψ´
 end
+
+similarmatrix(h, ::KrylovKitPackage) = similarmatrix(h)
 
 #######################################################################
 # shift and invert methods

--- a/src/diagonalizer.jl
+++ b/src/diagonalizer.jl
@@ -159,7 +159,7 @@ function sorteigs!(perm, ϵ::Vector, ψ::Matrix)
     resize!(perm, length(ϵ))
     p = sortperm!(perm, ϵ, by = real)
     # permute!(ϵ, p)
-    sort!(ϵ)
+    sort!(ϵ, by = real)
     Base.permutecols!!(ψ, p)
     return ϵ, ψ
 end

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -702,7 +702,7 @@ function _bloch!(matrix::AbstractMatrix, h::Hamiltonian{<:Lattice,L,M}, ϕs, axi
     rawmatrix = parent(matrix)
     if iszero(axis)
         _copy!(rawmatrix, first(h.harmonics).h) # faster copy!(dense, sparse) specialization
-        add_harmonics!(rawmatrix, h, ϕs, dn -> 1) 
+        add_harmonics!(rawmatrix, h, ϕs, dn -> 1)
     else
         fill!(rawmatrix, zero(M)) # There is no guarantee of same structure
         add_harmonics!(rawmatrix, h, ϕs, dn -> -im * dn[axis])

--- a/src/model.jl
+++ b/src/model.jl
@@ -85,7 +85,7 @@ function Base.show(io::IO, o::OnsiteTerm{F}) where {F}
     print(io,
 "$(i)OnsiteTerm{$(displayparameter(F))}:
 $(i)  Sublattices      : $(o.sublats === missing ? "any" : o.sublats)
-$(i)  Force Hermitian  : $(o.forcehermitian)
+$(i)  Force hermitian  : $(o.forcehermitian)
 $(i)  Coefficient      : $(o.coefficient)")
 end
 
@@ -96,7 +96,7 @@ function Base.show(io::IO, h::HoppingTerm{F}) where {F}
 $(i)  Sublattice pairs : $(h.sublats === missing ? "any" : (t -> Pair(reverse(t)...)).(h.sublats))
 $(i)  dn cell jumps    : $(h.dns === missing ? "any" : h.dns)
 $(i)  Hopping range    : $(round(h.range, digits = 6))
-$(i)  Force Hermitian  : $(h.forcehermitian)
+$(i)  Force hermitian  : $(h.forcehermitian)
 $(i)  Coefficient      : $(h.coefficient)")
 end
 
@@ -110,7 +110,7 @@ creating a `Hamiltonian` with `hamiltonian`.
 The onsite energy `o` can be a number, a matrix (preferably `SMatrix`) or a function of the
 form `r -> ...` for a position-dependent onsite energy. If `sublats` is specified as a
 sublattice name or tuple thereof, `onsite` is only applied to sublattices with said names.
-If `forcehermitian` is true, the model will produce an Hermitian Hamiltonian.
+If `forcehermitian` is true, the model will produce an hermitian Hamiltonian.
 
 The dimension of `o::AbstractMatrix` must match the orbital dimension of applicable
 sublattices (see also `orbitals` option for `hamiltonian`). If `o::Number` it will be
@@ -126,13 +126,13 @@ julia> onsite(1, sublats = (1,2)) - hopping(2)
 TightbindingModel{2}: model with 2 terms
   OnsiteTerm{Int64}:
     Sublattices      : (1, 2)
-    Force Hermitian  : true
+    Force hermitian  : true
     Coefficient      : 1
   HoppingTerm{Int64}:
     Sublattice pairs : any
     dn cell jumps    : any
     Hopping range    : 1.0
-    Force Hermitian  : true
+    Force hermitian  : true
     Coefficient      : -1
 
 julia> hamiltonian(LatticePresets.honeycomb(orbitals = (:a, :b)), onsite(r->@SMatrix[1 2; 3 4]))
@@ -166,7 +166,7 @@ The hopping amplitude `h` can be a number, a matrix (preferably `SMatrix`) or a 
 of the form `(r, dr) -> ...` for a position-dependent hopping (`r` is the bond center,
 and `dr` the bond vector). If `sublats` is specified as a sublattice name pair, or tuple
 thereof, `hopping` is only applied between sublattices with said names. If `forcehermitian`
-is true, the model will produce an Hermitian Hamiltonian.
+is true, the model will produce an hermitian Hamiltonian.
 
 The dimension of `h::AbstractMatrix` must match the orbital dimension of applicable
 sublattices (see also `orbitals` option for `hamiltonian`). If `h::Number` it will be
@@ -182,13 +182,13 @@ julia> onsite(1) - hopping(2, dn = ((1,2), (0,0)), sublats = (1,1))
 TightbindingModel{2}: model with 2 terms
   OnsiteTerm{Int64}:
     Sublattices      : any
-    Force Hermitian  : true
+    Force hermitian  : true
     Coefficient      : 1
   HoppingTerm{Int64}:
     Sublattice pairs : (1 => 1,)
     dn cell jumps    : ([1, 2], [0, 0])
     Hopping range    : 1.0
-    Force Hermitian  : true
+    Force hermitian  : true
     Coefficient      : -1
 
 julia> hamiltonian(LatticePresets.honeycomb(), hopping((r,dr) -> cos(r[1]), sublats = ((1,1), (2,2))))

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -343,7 +343,7 @@ tuplesort(::Missing) = missing
 
 # Like copyto! but with potentially different tensor orders (adapted from Base.copyto!)
 function copyslice!(dest::AbstractArray{T1,N1}, Rdest::CartesianIndices{N1},
-                    src::AbstractArray{T2,N2}, Rsrc::CartesianIndices{N2}) where {T1,T2,N1,N2}
+                    src::AbstractArray{T2,N2}, Rsrc::CartesianIndices{N2}, by = identity) where {T1,T2,N1,N2}
     isempty(Rdest) && return dest
     if length(Rdest) != length(Rsrc)
         throw(ArgumentError("source and destination must have same length (got $(length(Rsrc)) and $(length(Rdest)))"))
@@ -354,7 +354,7 @@ function copyslice!(dest::AbstractArray{T1,N1}, Rdest::CartesianIndices{N1},
     checkbounds(src, last(Rsrc))
     src′ = Base.unalias(dest, src)
     @inbounds for (Is, Id) in zip(Rsrc, Rdest)
-        @inbounds dest[Id] = src′[Is]
+        @inbounds dest[Id] = by(src′[Is])
     end
     return dest
 end


### PR DESCRIPTION
This partially reverts #36 following a comment by @BacAmorim .

The idea of #36 was to wrap the work matrix for `bloch!` in `Hermitian`. When passed to `diagonalize`, the `Hermitian` wrapper signaled the intent to obtain real eigenvalues. Part of the criticism (slow diagonalization with `Hermitian` wrappers) does not apply in recent versions of Julia, but nevertheless, the whole Hermitian design seemed unnecessary.

In this PR we no longer force a Hermitian wrapper on the output of `bloch!`. We allow `diagonalize` to return complex or real eigenvalues (this depends on the package used). However, when grouping all eigenvalues/vectors into subbands we force a conversion of eigenvalues to their real part only if momenta are real, or make them complex if momenta are complex. The result are subband meshes with vertices (k, ϵ) of uniform type. 

Of course, the usual situation is to provide `bandstructure` with a mesh of real momenta, so eigenvalues will typically be truncated to their real part. It is up to the user (using future API extensions) to provide a complex momentum mesh if one is dealing with bandstructures of non-hermitian Hamiltonians and one needs to preserve the information of the imaginary energies. This design seems overall more sane to me, and does not impose such a bias towards the hermitian case.