### PR TITLE
Allow models with sublats in arguments

### DIFF
--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -568,6 +568,7 @@ function applyterm!(builder::IJVBuilder{L,M}, term::HoppingTerm, termsublats) wh
     for (s1, s2) in termsublats
         is, js = siterange(lat, s1), siterange(lat, s2)
         dns = dniter(term.dns, Val(L))
+        name1, name2 = sublatname(lat, s1), sublatname(lat, s2)
         for dn in dns
             addadjoint = term.forcehermitian
             foundlink = false
@@ -582,7 +583,7 @@ function applyterm!(builder::IJVBuilder{L,M}, term::HoppingTerm, termsublats) wh
                     foundlink = true
                     rtarget = lat.unitcell.sites[i]
                     r, dr = _rdr(rsource, rtarget)
-                    vs = orbsized(term(r, dr), builder.orbs[s1], builder.orbs[s2])
+                    vs = orbsized(term(r, dr, name1, name2), builder.orbs[s1], builder.orbs[s2])
                     v = padtotype(vs, M)
                     if addadjoint
                         v *= redundancyfactor(dn, (s1, s2), term)

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -552,9 +552,10 @@ function applyterm!(builder::IJVBuilder{L,M}, term::OnsiteTerm, termsublats) whe
         dn0 = zero(SVector{L,Int})
         ijv = builder[dn0]
         offset = lat.unitcell.offsets[s]
+        name = sublatname(lat, s)
         for i in is
             r = lat.unitcell.sites[i]
-            vs = orbsized(term(r,r), builder.orbs[s])
+            vs = orbsized(term(r, r, name, name), builder.orbs[s])
             v = padtotype(vs, M)
             term.forcehermitian ? push!(ijv, (i, i, 0.5 * (v + v'))) : push!(ijv, (i, i, v))
         end

--- a/src/lattice.jl
+++ b/src/lattice.jl
@@ -198,6 +198,8 @@ nsublats(u::Unitcell) = length(u.names)
 
 sublats(u::Unitcell) = 1:nsublats(u)
 
+sublatname(u::Unitcell, s) = u.names[s]
+
 transform!(u::Unitcell, f::Function) = (u.sites .= f.(u.sites); u)
 
 Base.copy(u::Unitcell) = Unitcell(copy(u.sites), u.names, copy(u.offsets))
@@ -388,6 +390,8 @@ siteindex(lat::AbstractLattice, sublat, idx) = siteindex(lat.unitcell, sublat, i
 offsets(lat::AbstractLattice) = offsets(lat.unitcell)
 
 sublatsites(lat::AbstractLattice) = sublatsites(lat.unitcell)
+
+sublatname(lat::AbstractLattice, s) = sublatname(lat.unitcell, s)
 
 nsites(lat::AbstractLattice) = nsites(lat.unitcell)
 nsites(lat::AbstractLattice, sublat) = nsites(lat.unitcell, sublat)

--- a/src/model.jl
+++ b/src/model.jl
@@ -1,5 +1,5 @@
 #######################################################################
-# Function wrappers
+# Function wrappers with fixed number of arguments
 #######################################################################
 struct FixedArgs{N,F}
     f::F
@@ -50,12 +50,12 @@ struct HoppingTerm{F,
     forcehermitian::Bool
 end
 
-(o::OnsiteTerm{<:FixedArgs{1}})(r, dr, s1, s2) = o.coefficient * o.o(r)
-(o::OnsiteTerm{<:FixedArgs{2}})(r, dr, s1, s2) = o.coefficient * o.o(r, s1)
+(o::OnsiteTerm{<:FixedArgs{1}})(r, dr, s1, s2) = o.coefficient * o.o.f(r)
+(o::OnsiteTerm{<:FixedArgs{2}})(r, dr, s1, s2) = o.coefficient * o.o.f(r, s1)
 (o::OnsiteTerm)(r, dr, s1, s2) = o.coefficient * o.o
 
-(h::HoppingTerm{<:FixedArgs{2}})(r, dr, s1, s2) = h.coefficient * h.h(r, dr)
-(h::HoppingTerm{<:FixedArgs{4}})(r, dr, s1, s2) = h.coefficient * h.h(r, dr, s1, s2)
+(h::HoppingTerm{<:FixedArgs{2}})(r, dr, s1, s2) = h.coefficient * h.h.f(r, dr)
+(h::HoppingTerm{<:FixedArgs{4}})(r, dr, s1, s2) = h.coefficient * h.h.f(r, dr, s1, s2)
 (h::HoppingTerm)(r, dr, s1, s2) = h.coefficient * h.h
 
 sanitize_sublats(s::Missing) = missing
@@ -336,7 +336,8 @@ end
 
 function _checkmodelorbs(term::OnsiteTerm, orbs, lat)
     for s in sublats(term, lat)
-        _checkmodelorbs(term(first(sites(lat, s)), first(sites(lat, s))), length(orbs[s]))
+        name = sublatname(lat, s)
+        _checkmodelorbs(term(first(sites(lat, s)), first(sites(lat, s)), name, name), length(orbs[s]))
     end
     return nothing
 end

--- a/test/test_model.jl
+++ b/test/test_model.jl
@@ -2,7 +2,7 @@ module ModelTest
 
 using Test
 using Elsa
-using Elsa: TightbindingModel, OnsiteTerm, HoppingTerm, padtotype
+using Elsa: TightbindingModel, OnsiteTerm, HoppingTerm, padtotype, FixedArgs
 
 @testset "onsite" begin
     r = SVector(0.0, 0.0)
@@ -13,10 +13,10 @@ using Elsa: TightbindingModel, OnsiteTerm, HoppingTerm, padtotype
     for o in os, s in ss, c in cs
         ons = c * onsite(o, sublats = s)
         @test ons isa
-            TightbindingModel{1,Tuple{OnsiteTerm{typeof(o),S,typeof(c)}}} where S
+            TightbindingModel{1,Tuple{OnsiteTerm{typeof(FixedArgs(o)),S,typeof(c)}}} where S
         term = first(ons.terms)
         for t in ts
-            @test padtotype(term(r, r), t) isa t
+            @test padtotype(term(r, r, :A, :A), t) isa t
         end
     end
 end
@@ -32,10 +32,10 @@ end
     for h in hs, s in ss, c in cs, d in dns, r in rs
         hop = c * hopping(h, sublats = s, dn = d, range = r)
         @test hop isa
-            TightbindingModel{1,Tuple{HoppingTerm{typeof(h),S,D,typeof(float(r)),typeof(c)}}} where {S,D}
+            TightbindingModel{1,Tuple{HoppingTerm{typeof(FixedArgs(h)),S,D,typeof(float(r)),typeof(c)}}} where {S,D}
         term = first(hop.terms)
         for t in ts
-            @test padtotype(term(r, r), t) isa t
+            @test padtotype(term(r, r, :A, :A), t) isa t
         end
     end
 end
@@ -43,12 +43,12 @@ end
 @testset "term algebra" begin
     r = SVector(0, 0)
     model = onsite(1) + hopping(2I)
-    @test (t -> t(r, r)).(model.terms) == (1, 2I)
+    @test (t -> t(r, r, :A, :A)).(model.terms) == (1, 2I)
     model = onsite(1) - hopping(2I)
-    @test (t -> t(r, r)).(model.terms) == (1, -2I)
+    @test (t -> t(r, r, :A, :A)).(model.terms) == (1, -2I)
     model = -onsite(@SMatrix[1 0; 1 1]) - 2hopping(2I)
-    @test (t -> t(r, r)).(model.terms) == (-@SMatrix[1 0; 1 1], -4I)
-    @test model(r, r) == @SMatrix[-5 0; -1 -5]
+    @test (t -> t(r, r, :A, :A)).(model.terms) == (-@SMatrix[1 0; 1 1], -4I)
+    # @test model(r, r, :A, :A) == @SMatrix[-5 0; -1 -5]
 end
 
 end # module


### PR DESCRIPTION
Fixes #42 
This is a quick PR that implements the feature in #42 whereby we may write models with hopping or onsite functions that take sublattice names as arguments
```
model = onsite((r, s) -> s == :B ? 1 : 0) + hopping((r, dr, s1, s2) -> s1 == s2 == :A ? 1 : 0);
h = LatticePresets.honeycomb() |> hamiltonian(model)
```

The approach is to wrap the hopping function in an auxiliary type `FixedArgs{N}` where `N` is the number of arguments applicable to the hopping function (four in this case). Then, evaluation of a term dispatches on this type. Internally the arguments are always `term(r, dr, s1, s2)` for any model term, regardless of whether `dr, s1, s2` are used or not (not convinced about this, there might be some more elegant way).

The only drawback of this is that there is a slight overhead of building any system that takes a function, probably due to the fact that we need to pass an argument (sublattice name) that is not an `isbits` type (it is a `NameType == Symbol`, such as `:A`). The overhead is quite small for big systems, however. It probably pays off.

Benchmarks using `f(hop) = LatticePresets.honeycomb() |> hamiltonian(hop) |> unitcell(region = RegionPresets.circle(300))`

Before this PR, old API
```
julia> hop = hopping((r, dr) -> 1, sublats = (:A,:A)) + hopping((r, dr) -> -1, sublats = (:B,:B));
julia> @btime f($hop);
  331.066 ms (460 allocations: 124.43 MiB)
```

With this PR, old API
```
julia> hop = hopping((r, dr) -> 1, sublats = (:A,:A)) + hopping((r, dr) -> -1, sublats = (:B,:B));
julia> @btime f($hop);
  338.537 ms (460 allocations: 124.43 MiB)
```

With this PR, new API
```
julia> hop = hopping((r, dr, s1, s2) -> ifelse(s1 == :A, 1, -1), sublats = ((:A,:A), (:B,:B)));
julia> @btime f($hop);
  338.174 ms (454 allocations: 124.43 MiB)
```