### PR TITLE
Move field to kws in unitcell(::Hamiltonian)

### DIFF
--- a/src/Elsa.jl
+++ b/src/Elsa.jl
@@ -15,7 +15,7 @@ using StaticArrays, NearestNeighbors, SparseArrays, LinearAlgebra, OffsetArrays,
 
 using SparseArrays: getcolptr, AbstractSparseMatrixCSC
 
-export sublat, bravais, lattice, dims, hopping, onsite, hamiltonian, randomstate,
+export sublat, bravais, lattice, dims, hopping, onsite, hamiltonian,
        mul!, supercell, unitcell, semibounded, bloch, bloch!, optimize!, similarmatrix,
        sites, bandstructure, marchingmesh, defaultmethod, bands, vertices, states,
        flatten, wrap, transform!, combine,
@@ -38,9 +38,7 @@ include("iterators.jl")
 include("presets.jl")
 include("lattice.jl")
 include("model.jl")
-include("field.jl")
 include("hamiltonian.jl")
-include("state.jl")
 include("mesh.jl")
 include("diagonalizer.jl")
 include("bandstructure.jl")

--- a/src/field.jl
+++ b/src/field.jl
@@ -16,7 +16,7 @@ Field(f::F, lat) where {F<:Function} = Field(f, lat, NamedTuple())
 @inline applyfield(::Missing, h, i, j, dn) = h
 function applyfield(field::Field{F}, h, i, j, dn) where {F<:Function}
     sites = field.lat.unitcell.sites
-    r, dr = _rdr(sites[j], sites[i]) # rsource, rtarget
     r0 = field.lat.bravais.matrix * dn
-    return field.f(r + r0, dr, h)
+    r, dr = _rdr(sites[j], sites[i] + r0) # rsource, rtarget
+    return field.f(r, dr, h)
 end

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -692,7 +692,7 @@ function applytransform(val::T, onsite, hopping, lat, isrc, dnsrc, idst, dndst) 
     br = bravais(lat)
     if isrc == idst && dnsrc == dndst
         r = rs[isrc] + br * dnsrc
-        return onsite == missing ? val : T(onsite(val, r))
+        return onsite === missing ? val : T(onsite(val, r))
     else
         r, dr = _rdr(rs[isrc] + br * dnsrc, rs[idst] + br * dndst)
         return hopping === missing ? val : T(hopping(val, r, dr))

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -687,27 +687,16 @@ wrap_dn(olddn::SVector, newdn::SVector, supercell::SMatrix) = olddn - supercell 
 
 applytransform(val, ::Missing, ::Missing, _...) = val
 
-function applytransform(val, onsite, hopping, lat, isrc, dnsrc, idst, dndst)
-    val´ = isrc == idst && dnsrc == dndst ?
-        _applytransform(val, onsite, lat, isrc, dnsrc) :
-        _applytransform(val, hopping, lat, isrc, dnsrc, idst, dndst)
-    return val´
-end
-
-_applytransform(val, ::Missing, _...) = val
-
-function _applytransform(val, onsite, lat, isrc, dnsrc)
+function applytransform(val::T, onsite, hopping, lat, isrc, dnsrc, idst, dndst) where {T}
     rs = sites(lat)
     br = bravais(lat)
-    r = rs[isrc] + br * dnsrc
-    return onsite(val, r)
-end
-
-function _applytransform(val, hopping, lat, isrc, dnsrc, idst, dndst)
-    rs = sites(lat)
-    br = bravais(lat)
-    r, dr = _rdr(rs[isrc] + br * dnsrc, rs[idst] + br * dndst)
-    return hopping(val, r, dr)
+    if isrc == idst && dnsrc == dndst
+        r = rs[isrc] + br * dnsrc
+        return onsite == missing ? val : T(onsite(val, r))
+    else
+        r, dr = _rdr(rs[isrc] + br * dnsrc, rs[idst] + br * dndst)
+        return hopping === missing ? val : T(hopping(val, r, dr))
+    end
 end
 
 #######################################################################

--- a/src/lattice.jl
+++ b/src/lattice.jl
@@ -360,7 +360,7 @@ function foreach_supersite(f::F, lat::Superlattice) where {F<:Function}
         for dn in CartesianIndices(lat.supercell)
             if isinmask(lat.supercell, oldi, dn)
                 newi += 1
-                f(s, oldi, SVector(Tuple(dn)), newi)
+                f(s, oldi, toSVector(Int, Tuple(dn)), newi)
             end
         end
     end
@@ -584,7 +584,7 @@ function _supercell(lat::AbstractLattice{E,L}, scmatrix::SMatrix{L,L´,Int}, reg
     mask = OffsetArray(BitArray(undef, ns, size(cells)...), 1:ns, cells.indices...)
     @inbounds for dn in cells
         dntup = Tuple(dn)
-        dnvec = SVector(dntup)
+        dnvec = toSVector(Int, dntup)
         in_supercell = in_supercell_func(dnvec)
         in_supercell || (mask[:, dntup...] .= false; continue)
         r0 = brmatrix * dnvec
@@ -628,8 +628,8 @@ function supercell_cells(lat::Lattice{E,L}, regionfunc, in_supercell_func) where
         found = false
         counter += 1; counter == TOOMANYITERS &&
             throw(ArgumentError("`region` seems unbounded (after $TOOMANYITERS iterations)"))
-        in_supercell = in_supercell_func(SVector(Tuple(dn)))
-        r0 = bravais * SVector(Tuple(dn))
+        in_supercell = in_supercell_func(toSVector(Int, dn))
+        r0 = bravais * toSVector(Int, dn)
         for site in lat.unitcell.sites
             r = r0 + site
             found = in_supercell && regionfunc(r)

--- a/src/lattice.jl
+++ b/src/lattice.jl
@@ -367,7 +367,7 @@ function foreach_supersite(f::F, lat::Superlattice) where {F<:Function}
     return nothing
 end
 
-issemibounded(lat::Superlattice) where {L} = issemibounded(lat.supercell)
+issemibounded(lat::Superlattice) = issemibounded(lat.supercell)
 
 #######################################################################
 # AbstractLattice interface

--- a/src/lattice.jl
+++ b/src/lattice.jl
@@ -603,8 +603,6 @@ is_perp_dir(supercell) = let invs = pinvmultiple(supercell); dn -> iszero(new_dn
 new_dn(oldndist, (pinvs, n)) = fld.(pinvs * oldndist, n)
 new_dn(oldndist, ::Tuple{<:SMatrix{0,0},Int}) = SVector{0,Int}()
 
-wrap_dn(olddn::SVector, newdn::SVector, supercell::SMatrix) = olddn - supercell * newdn
-
 function ribbonfunc(bravais::SMatrix{E,L,T}, supercell::SMatrix{L,L´}) where {E,L,T,L´}
     L <= L´ && return r -> true
     # real-space supercell axes + all space
@@ -689,18 +687,25 @@ Calls `unitcell` with a uniformly scaled `uc = SMatrix{L,L}(factor * I)`
 Calls `unitcell` with different scaling along each Bravais vector (diagonal supercell
 with factors along the diagonal)
 
-    lattice |> unitcell(v...; kw...)
-
-Functional syntax, equivalent to `unitcell(lattice, v...; kw...)
-
     unitcell(slat::Superlattice)
 
 Convert Superlattice `slat` into a lattice with its unit cell matching `slat`'s supercell.
 
-    unitcell(h::Hamiltonian, v...; kw...)
+    unitcell(h::Hamiltonian, v...; onsitefield = missing, hoppingfield = missing, kw...)
 
-Transforms the `Lattice` of `h` to have a larger unitcell, and expanding the Hamiltonian
-accordingly.
+Transforms the `Lattice` of `h` to have a larger unitcell, while expanding the Hamiltonian
+accordingly. If not missing, the function `onsitefield(o, r)` is applied to each onsite
+energy 'o' of sites at position `r`, and `hoppingfield(h, r, dr)` is applied to hoppings `h`
+between sites at positions `r1, r2 = r - dr/2, r + dr/2`. 
+
+Note: for performance reasons, in sparse hamiltonians only the stored `o`s and `h`s will be
+transformed by these fields, so you might want to add zero onsites or hoppings when building
+`h` to have a field applied to them. Note also that additional `o`s and `h`s may be stored
+when calling `optimize!` or `bloch`/`bloch!` on `h` for the first time.
+
+    lat_or_h |> unitcell(v...; kw...)
+
+Functional syntax, equivalent to `unitcell(lat_or_h, v...; kw...)
 
 # Examples
 ```jldoctest

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -3,6 +3,7 @@ module HamiltonianTest
 using Elsa
 using Test
 using Elsa: Hamiltonian
+using LinearAlgebra: diag
 
 @testset "basic hamiltonians" begin
     presets = (LatticePresets.linear, LatticePresets.square, LatticePresets.triangular,
@@ -34,6 +35,11 @@ end
     h2 = hamiltonian(lat, onsite(1) + hopping(@SMatrix[1 2], sublats = ((:A,:B),)),
                       orbitals = :B => Val(2))
     @test bloch(h1, 1, 2) == bloch(h2, 1, 2)
+end
+
+@testset "fields" begin
+    h = LatticePresets.honeycomb() |> hamiltonian(hopping(1) + onsite(0)) |> unitcell(2, onsitefield = (o, r) -> 1)
+    @test diag(bloch(h)) == ComplexF64[1, 1, 1, 1, 1, 1, 1, 1]
 end
 
 end # module


### PR DESCRIPTION
Having to carry around a field in `Hamiltonian` for possible application when making it grow (with e.g. unitcell) was overly complicated. It is more natural to have fields be an option of `unitcell(h::Hamiltonian,...)`, to be applied as one grows `h`

This PR does just that. We can now say `unitcell(h::Hamiltonian, args...; onsitefield = (o, r) ->..., hoppingfield -> (h, r, dr) -> ..., kw...)` and have these fields applied when expanding the hamiltonian to the new unit cell.

Important observation: for sparse hamiltonians (dense not yet implemented) only stored onsites and hoppings are transformed, so it makes sense to add e.g. onsite(0) to a Hamiltonian without onsites to be able to apply an `onsitefield` later.

Example
```
julia> h = LatticePresets.honeycomb() |> hamiltonian(hopping(1) + onsite(0)); field(o, r) = o + rand();
julia> @time unitcell(h, 100; onsitefield = field)  #after warmup
  0.025563 seconds (303 allocations: 12.065 MiB)
Hamiltonian{<:Lattice} : Hamiltonian on a 2D Lattice in 2D space
  Bloch harmonics  : 7 (SparseMatrixCSC, sparse)
  Harmonic size    : 20000 × 20000
  Orbitals         : ((:a,), (:a,))
  Element type     : scalar (Complex{Float64})
  Onsites          : 20000
  Hoppings         : 180000
  Coordination     : 9.0
```

The good thing about this is that we can build non-homogeneous hamiltonians very efficiently