### PR TITLE
RFC: Selector types for specifying subsets of onsites and hoppings

### DIFF
--- a/src/Elsa.jl
+++ b/src/Elsa.jl
@@ -16,6 +16,7 @@ using StaticArrays, NearestNeighbors, SparseArrays, LinearAlgebra, OffsetArrays,
 using SparseArrays: getcolptr, AbstractSparseMatrixCSC
 
 export sublat, bravais, lattice, dims, hopping, onsite, hamiltonian,
+       onsiteselector, hoppingselector,
        mul!, supercell, unitcell, semibounded, bloch, bloch!, optimize!, similarmatrix,
        sites, bandstructure, marchingmesh, defaultmethod, bands, vertices, states,
        flatten, wrap, transform!, combine,

--- a/src/lattice.jl
+++ b/src/lattice.jl
@@ -431,7 +431,7 @@ If all `lats` have compatible Bravais vectors, combine them into a single lattic
 Sublattice names are renamed to be unique if necessary.
 """
 function combine(lats::Lattice...)
-    is_bravais_compatible(lats...) || throw(ArgumentError("Lattices must share all Bravais vectors"))
+    is_bravais_compatible(lats...) || throw(ArgumentError("Lattices must share all Bravais vectors, $(bravais.(lats))"))
     bravais´ = first(lats).bravais
     unitcell´ = combine((l -> l.unitcell).(lats)...)
     return Lattice(bravais´, unitcell´)

--- a/src/presets.jl
+++ b/src/presets.jl
@@ -44,19 +44,19 @@ module HamiltonianPresets
 
 using Elsa, LinearAlgebra
 
-function graphene_bilayer(; twistindex = 1, twistindices = (twistindex, 1), a0 = 0.246,
-                            interlayerdistance = 1.36a0, rangeintralayer = a0/sqrt(3),
-                            rangeinterlayer = 4a0/sqrt(3), hopintra = 2.70, hopinter = 0.48,
-                            modelintra = hopping(hopintra, range = rangeintralayer),
-                            kw...)
+function twisted_bilayer_graphene(;
+    twistindex = 1, twistindices = (twistindex, 1), a0 = 0.246, interlayerdistance = 1.36a0,
+    rangeintralayer = a0/sqrt(3), rangeinterlayer = 4a0/sqrt(3), hopintra = 2.70,
+    hopinter = 0.48, modelintra = hopping(hopintra, range = rangeintralayer), kw...)
+
     (m, r) = twistindices
     θ = acos((3m^2 + 3m*r +r^2/2)/(3m^2 + 3m*r + r^2))
     sAbot = sublat((0.0, -0.5a0/sqrt(3.0), - interlayerdistance / 2); name = :Ab)
     sBbot = sublat((0.0,  0.5a0/sqrt(3.0), - interlayerdistance / 2); name = :Bb)
     sAtop = sublat((0.0, -0.5a0/sqrt(3.0),   interlayerdistance / 2); name = :At)
     sBtop = sublat((0.0,  0.5a0/sqrt(3.0),   interlayerdistance / 2); name = :Bt)
-    br = a0 * bravais(( cos(pi/3), sin(pi/3), 0),
-                      (-cos(pi/3), sin(pi/3), 0))
+    brbot = a0 * bravais(( cos(pi/3), sin(pi/3), 0), (-cos(pi/3), sin(pi/3), 0))
+    brtop = a0 * bravais((-cos(pi/3), sin(pi/3), 0), ( cos(pi/3), sin(pi/3), 0))
     # Supercell matrices sc.
     # The one here is a [1 0; -1 1] rotation of the one in Phys. Rev. B 86, 155449 (2012)
     if gcd(r, 3) == 1
@@ -66,9 +66,8 @@ function graphene_bilayer(; twistindex = 1, twistindices = (twistindex, 1), a0 =
         scbot = @SMatrix[m+r÷3 -r÷3; r÷3 m+2r÷3] * @SMatrix[1 0; -1 1]
         sctop = @SMatrix[m+2r÷3 r÷3; -r÷3 m+r÷3] * @SMatrix[1 0; -1 1]
     end
-
-    lattop = lattice(br, sAtop, sBtop)
-    latbot = lattice(br, sAbot, sBbot)
+    latbot = lattice(brbot, sAbot, sBbot)
+    lattop = lattice(brtop, sAtop, sBtop)
     htop = hamiltonian(lattop, modelintra; kw...) |> unitcell(sctop)
     hbot = hamiltonian(latbot, modelintra; kw...) |> unitcell(scbot)
     let R = @SMatrix[cos(θ/2) -sin(θ/2) 0; sin(θ/2) cos(θ/2) 0; 0 0 1]

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -10,13 +10,14 @@ using LinearAlgebra: diag
                LatticePresets.honeycomb, LatticePresets.cubic, LatticePresets.fcc,
                LatticePresets.bcc)
     ts = (1, 2.0, @SMatrix[1 2; 3 4])
+    orbs = (Val(1), Val(1), Val(2))
     for preset in presets, lat in (preset(), unitcell(preset()))
         E, L = dims(lat)
         dn0 = ntuple(_ -> 1, Val(L))
-        for t in ts
-            @test hamiltonian(lat, onsite(t) + hopping(t; range = 1)) isa Hamiltonian
-            @test hamiltonian(lat, onsite(t) - hopping(t; dn = dn0)) isa Hamiltonian
-            @test hamiltonian(lat, onsite(t) + hopping(t; dn = dn0, forcehermitian = false)) isa Hamiltonian
+        for (t, o) in zip(ts, orbs)
+            @test hamiltonian(lat, onsite(t) + hopping(t; range = 1), orbitals = o) isa Hamiltonian
+            @test hamiltonian(lat, onsite(t) - hopping(t; dn = dn0), orbitals = o) isa Hamiltonian
+            @test hamiltonian(lat, onsite(t) + hopping(t; dn = dn0, forcehermitian = false), orbitals = o) isa Hamiltonian
         end
     end
 end

--- a/test/test_model.jl
+++ b/test/test_model.jl
@@ -2,7 +2,7 @@ module ModelTest
 
 using Test
 using Elsa
-using Elsa: TightbindingModel, OnsiteTerm, HoppingTerm, padtotype
+using Elsa: TightbindingModel, OnsiteTerm, HoppingTerm, padtotype, Selector
 
 @testset "onsite" begin
     r = SVector(0.0, 0.0)
@@ -13,7 +13,7 @@ using Elsa: TightbindingModel, OnsiteTerm, HoppingTerm, padtotype
     for o in os, s in ss, c in cs
         ons = c * onsite(o, sublats = s)
         @test ons isa
-            TightbindingModel{1,Tuple{OnsiteTerm{typeof(o),S,typeof(c)}}} where S
+            TightbindingModel{1,<:Tuple{OnsiteTerm{typeof(o)}}}
         term = first(ons.terms)
         for t in ts
             @test padtotype(term(r, r), t) isa t
@@ -32,7 +32,7 @@ end
     for h in hs, s in ss, c in cs, d in dns, r in rs
         hop = c * hopping(h, sublats = s, dn = d, range = r)
         @test hop isa
-            TightbindingModel{1,Tuple{HoppingTerm{typeof(h),S,D,typeof(float(r)),typeof(c)}}} where {S,D}
+            TightbindingModel{1,<:Tuple{HoppingTerm{typeof(h)}}}
         term = first(hop.terms)
         for t in ts
             @test padtotype(term(r, r), t) isa t


### PR DESCRIPTION
This refactors the way we specify subsets of onsites and hoppings, as when defining a `TightbindingModel`. The new API functions are `onsiteselector(; region, sublats)` and `hoppingselector(; region, sublats, dn, range)`. Note that this adds the possibility to restrict the subset using a `region(r)` or `region(r, dr)` function, respectively.

The aim of the refactor is to encapsulate this functionality for reuse in other upcoming API functions, beyond `onsite` and `hopping`. One example is `onsite!` and `hopping!` that will shortly become the transformation machinery for `ParametricHamiltonian`. Another example will be `delete(ham, ::Selector...)` and `keep(ham, ::Selector...)` to delete or keep a subset of elements in a hamiltonian (calling `SparseArrays.fkeep!`). All that still to come.