### PR TITLE
Spectrum

### DIFF
--- a/src/Elsa.jl
+++ b/src/Elsa.jl
@@ -15,11 +15,11 @@ using StaticArrays, NearestNeighbors, SparseArrays, LinearAlgebra, OffsetArrays,
 
 using SparseArrays: getcolptr, AbstractSparseMatrix
 
-export sublat, bravais, lattice, dims, hopping, onsite, hamiltonian, parametric,
+export sublat, bravais, lattice, dims, sites, hopping, onsite, hamiltonian, parametric,
        onsiteselector, hoppingselector, onsite!, hopping!,
        mul!, supercell, unitcell, semibounded, bloch, bloch!, optimize!, similarmatrix,
-       sites, bandstructure, marchingmesh, defaultmethod, bands, vertices, states,
-       flatten, wrap, transform!, combine,
+       spectrum, bandstructure, marchingmesh, defaultmethod, bands, vertices,
+       energies, states, flatten, wrap, transform!, combine,
        momentaKPM, dosKPM, averageKPM, densityKPM
 
 export LatticePresets, RegionPresets, HamiltonianPresets

--- a/src/diagonalizer.jl
+++ b/src/diagonalizer.jl
@@ -13,6 +13,8 @@ end
 diagonalizer(h::Hamiltonian, mesh::Mesh, method, minprojection) =
     Diagonalizer(method, codiagonalizer(h, mesh), minprojection)
 
+## Diagonalize methods ##
+
 function defaultmethod(h::Hamiltonian)
     if eltype(h) <: Number
         # method = issparse(h) ? ArpackPackage() : LinearAlgebraPackage()
@@ -34,8 +36,8 @@ end
 
 LinearAlgebraPackage(; kw...) = LinearAlgebraPackage(values(kw))
 
-function diagonalize(matrix, d::Diagonalizer{<:LinearAlgebraPackage})
-    ϵ, ψ = eigen!(matrix; (d.method.kw)...)
+function diagonalize(matrix, method::LinearAlgebraPackage)
+    ϵ, ψ = eigen!(matrix; (method.kw)...)
     return ϵ, ψ
 end
 
@@ -48,8 +50,8 @@ end
 
 ArpackPackage(; kw...) = (checkloaded(:Arpack); ArpackPackage(values(kw)))
 
-function diagonalize(matrix, d::Diagonalizer{<:ArpackPackage})
-    ϵ, ψ = Main.Arpack.eigs(matrix; (d.method.kw)...)
+function diagonalize(matrix, method::ArpackPackage)
+    ϵ, ψ = Main.Arpack.eigs(matrix; (method.kw)...)
     return ϵ, ψ
 end
 
@@ -63,11 +65,11 @@ end
 
 KrylovKitPackage(; kw...) = (checkloaded(:KrylovKit); KrylovKitPackage(values(kw)))
 
-function diagonalize(matrix::AbstractMatrix{M}, d::Diagonalizer{<:KrylovKitPackage}) where {M}
+function diagonalize(matrix::AbstractMatrix{M}, method::KrylovKitPackage) where {M}
     ishermitian(matrix) || throw(ArgumentError("Only Hermitian matrices supported with KrylovKitPackage for the moment"))
-    origin = get(d.method.kw, :origin, 0.0)
-    howmany = get(d.method.kw, :howmany, 1)
-    kw´ = Base.structdiff(d.method.kw, NamedTuple{(:origin,:howmany)}) # Remove origin option
+    origin = get(method.kw, :origin, 0.0)
+    howmany = get(method.kw, :howmany, 1)
+    kw´ = Base.structdiff(method.kw, NamedTuple{(:origin,:howmany)}) # Remove origin option
     lmap = shiftandinvert(matrix, origin)
     T = eltypevec(matrix)
     n = size(matrix, 2)

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -99,6 +99,9 @@ blockdim(h::Hamiltonian) = blockdim(blocktype(h))
 blockdim(::Type{S}) where {N,S<:SMatrix{N,N}} = N
 blockdim(::Type{T}) where {T<:Number} = 1
 
+checkfinitedim(h::Hamiltonian{LA,L}) where {LA,L} =
+    L == 0 && throw(ArgumentError("A finite-dimensional Hamiltonian is required, not zero-dimensional"))
+
 function nhoppings(ham::Hamiltonian)
     count = 0
     for h in ham.harmonics

--- a/src/mesh.jl
+++ b/src/mesh.jl
@@ -145,7 +145,10 @@ function marchingmesh(npoints::Vararg{Integer,L}; axes = 1.0 * I, shift = missin
     return _marchingmesh(ranges´, SMatrix{L,L}(axes))
 end
 
+marchingmesh(; kw...) = throw(ArgumentError("Need a finite number of points"))
+
 function marchingmesh(h::Hamiltonian{<:Lattice,L}; npoints = 13, shift = missing) where {L}
+    checkfinitedim(h)
     ranges = meshranges(npoints, Val(L))
     ranges´ = shiftranges(ranges, shift)
     return _marchingmesh(ranges´, SMatrix{L,L}(I))
@@ -158,7 +161,7 @@ shiftranges(rs, shift::Missing) = rs
 shiftranges(rs::NTuple{L}, shift::Number) where {L} = shiftranges(rs, filltuple(shift, Val(L)))
 shiftranges(rs::NTuple{L}, shifts::NTuple{L}) where {L} = ((r, s) -> r .+ s).(rs, shifts)
 
-function _marchingmesh(ranges::NTuple{D,AbstractRange}, axes::SMatrix{D,D}) where {D,T<:AbstractFloat}
+function _marchingmesh(ranges::NTuple{D,AbstractRange}, axes::SMatrix{D,D}) where {D}
     npoints = length.(ranges)
     projection = axes' # ./ (SVector(npoints) - 1)' # Projects binary vector to m box with npoints
     cs = CartesianIndices(ntuple(n -> 1:npoints[n], Val(D)))


### PR DESCRIPTION
This introduces `spectrum(h; method = ...)` in place of `bandstructure` for zero-dimensional (bounded) Hamiltonians. It makes sense to have a different path in this case, as all the machinery for band extraction and degeneracy resolution in `bandstructure` does not apply. The energies and states in the resulting `s::Spectrum` object can be done via `energies(s)` and `states(s)`